### PR TITLE
Issue #2229887 by drkloc

### DIFF
--- a/dkan_dataset.triggers.inc
+++ b/dkan_dataset.triggers.inc
@@ -9,12 +9,59 @@
  * Implements hook_node_update().
  */
 function dkan_dataset_node_update($node) {
-  if ($node->type == 'resource') {
-    ctools_include('Dataset', 'dkan_dataset');
-    foreach ($node->field_dataset_ref['und'] as $dataset_nid) {
-      $dataset = Dataset::instance($dataset_nid['target_id']);
-      $dataset->incrementRevision('Update to resource \'' . $node->title . '\'');
-      $dataset->save();
-    }
+  global $user;
+  switch ($node->type) {
+    case 'resource':
+      $datasets = $node->field_dataset_ref[LANGUAGE_NONE];
+      if (count($datasets)) {
+        $queue = DrupalQueue::get('dataset_changelog');
+        foreach ($datasets as $dataset) {
+          $item = array(
+            'dataset' => $dataset['target_id'],
+            'message' => 'Update to resource \'' . $node->title . '\'',
+            'user' => $user->uid,
+          );
+          $queue->createItem($item);
+        }
+      }
+      break;
+
+    default:
+      break;
+
   }
+}
+
+/**
+ * Implements hook_queue_info().
+ */
+function dkan_dataset_cron_queue_info() {
+  $queues = array();
+  $queues['dataset_changelog'] = array(
+    'worker callback' => 'dkan_dataset_dataset_changelog_run',
+    'time' => 20,
+  );
+  return $queues;
+}
+
+/**
+ * Callback for dkan_dataset_dataset_changelog cron worker.
+ * @param  array $item
+ *   An associative array containing the dataset nid and a log message.
+ */
+function dkan_dataset_dataset_changelog_run($item) {
+  global $user;
+  $original_user = $user;
+  drupal_save_session(FALSE);
+  // Increment Revision
+  if (isset($item['user']) && isset($item['dataset']) && isset($item['message'])) {
+    $user = user_load($item['user']);
+    ctools_include('Dataset', 'dkan_dataset');
+    $dataset = Dataset::instance($item['dataset']);
+    $dataset->incrementRevision($item['message']);
+    $dataset->save();
+  }
+  // Restore Anonymous user.
+  $user = $original_user;
+  drupal_save_session(TRUE);
 }

--- a/includes/Dataset.inc
+++ b/includes/Dataset.inc
@@ -152,16 +152,20 @@ class Dataset {
     if ($node) {
       $this->title = $node->title;
       $this->dataset = $node;
-      $this->resources = array();
-      // Load resources.
-      foreach ($this->dataset->field_resources[$this->dataset->language] as $key => $resource) {
-        $this->resources[] = node_load($resource['target_id']);
-      }
       // Removed unset($this->dataset->field_resources);.
       $this->created = TRUE;
     }
   }
 
+  protected function preloadResources() {
+    if ($this->created) {
+       $this->resources = array();
+      // Load resources.
+      foreach ($this->dataset->field_resources[$this->dataset->language] as $key => $resource) {
+        $this->resources[] = node_load($resource['target_id']);
+      }
+    }
+  }
   /**
    * Constructor.
    *


### PR DESCRIPTION
- Set dataset revision increment when resource change to happen during cron runs
- Populating DrupalQueue avoiding hook_cron
- Counting dataset ref nodes to see if we update the queue
