### PR TITLE
trim html support

### DIFF
--- a/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
@@ -284,6 +284,7 @@ function dkan_dataset_groups_views_default_views() {
   $handler->display->display_options['fields']['body']['label'] = '';
   $handler->display->display_options['fields']['body']['alter']['max_length'] = '200';
   $handler->display->display_options['fields']['body']['alter']['trim'] = TRUE;
+  $handler->display->display_options['fields']['body']['alter']['html'] = TRUE;
   $handler->display->display_options['fields']['body']['element_label_colon'] = FALSE;
   /* Sort criterion: Content: Post date */
   $handler->display->display_options['sorts']['created']['id'] = 'created';


### PR DESCRIPTION
This is needed in order to not broke html description on dataset page.
