### PR TITLE
Issue NuCivic/dkan#136: Adding download link next to explore data link f...

### DIFF
--- a/dkan_dataset.theme.inc
+++ b/dkan_dataset.theme.inc
@@ -75,7 +75,32 @@ function theme_dkan_dataset_resource_view($vars) {
       else {
         $term = '<span class="format-label" property="dc:format" data-format="data">Data</span>';
       }
-      $explore_link = l(t('Explore Data'), 'node/' . $node->nid, array('attributes' => array('class' => array('btn', 'btn-primary'))));
+      $explore_link = l(
+        t('Explore Data'),
+        'node/' . $node->nid,
+        array(
+          'attributes' => array(
+            'class' => array(
+              'btn',
+              'btn-primary'
+            )
+          )
+        )
+      );
+      $download_link = '';
+      if (isset($node->field_upload[LANGUAGE_NONE])) {
+        $url = file_create_url($node->field_upload[LANGUAGE_NONE][0]['uri']);
+        $download_link = l(
+          '<i class="fa fa-download"></i>',
+          $url,
+          array(
+            'html' => TRUE,
+            'attributes' => array(
+              'class' => array('btn', 'btn-primary'),
+            ),
+          )
+        );
+      }
       $dcat = '<div property="dcat:Distribution">';
       $links[] = $dcat . l($node->title . $term, 'node/' . $node->nid, array(
         'html' => TRUE,
@@ -84,7 +109,7 @@ function theme_dkan_dataset_resource_view($vars) {
           'title' => $node->title,
           'property' => 'dcat:accessURL',
         ))
-      ) . $desc . $explore_link . '</div>';
+      ) . $desc . '<span class="links">' . $explore_link . $download_link . '</span></div>';
     }
 
     $output = theme('item_list', array('items' => $links, 'attributes' => array('class' => array('resource-list'))));


### PR DESCRIPTION
...or each resource in dataset page

Issue NuCivic/dkan#136
## Acceptance Test

You need to see the download button next to 'Explore Data'

![screen shot 2014-06-18 at 3 46 43 pm](https://cloud.githubusercontent.com/assets/428070/3319527/5f642faa-f721-11e3-9fcb-07a63a3554b1.png)
