### PR TITLE
NuCivic/nucivic-internal#58 adding pathauto dependency.

### DIFF
--- a/dkan_dataset.make
+++ b/dkan_dataset.make
@@ -176,6 +176,9 @@ projects[views_responsive_grid][subdir] = contrib
 projects[views_bulk_operations][version] = 3.2
 projects[views_bulk_operations][subdir] = contrib
 
+projects[pathauto][version] = 1.2
+projects[pathauto][subdir] = contrib
+
 ; Libraries
 libraries[chosen][type] = libraries
 libraries[chosen][download][type] = git


### PR DESCRIPTION
NuCivic/nucivic-internal#58

Its used for open_data_schema_map_ckan to build the name field of each node
