### PR TITLE
NuCivic/nucivic-internal#204 Creating taxonomies on setup test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - drush --yes core-quick-drupal --profile=testing --no-server --db-url=mysql://root:@127.0.0.1/dkan_dataset_test --enable=simpletest dkan_dataset_test
 
   # Grab dkan to have the dkan_default_content module at hand
-  - git clone --branch 7.x-1.x http://git.drupal.org/project/dkan.git
+  - git clone --branch 7.x-1.x https://github.com/NuCivic/dkan.git
 
   # copy dkan_dataset to sites/all
   - cp -r $TRAVIS_BUILD_DIR dkan_dataset_test/drupal/sites/all/modules/dkan_dataset
@@ -42,6 +42,7 @@ before_script:
   - drush --yes pm-enable dkan_dataset
   - drush --yes pm-enable dkan_dataset_groups
   - drush --yes pm-enable dkan_dataset_api
+  - drush --yes pm-enable dkan_default_content
 
   # start a web server on port 8080, run in the background; wait for initialization
   - drush runserver 127.0.0.1:8080 &

--- a/tests/dkan_dataset.test
+++ b/tests/dkan_dataset.test
@@ -63,6 +63,7 @@ class DkanDatasetWebTestCase extends DrupalWebTestCase {
     $modules[] = 'dkan_dataset';
     $modules[] = 'dkan_dataset_groups';
     $modules[] = 'dkan_dataset_content_types';
+    $modules[] = 'dkan_default_content';
     $modules[] = 'features';
     $modules[] = 'double_field';
     $modules[] = 'entityreference';

--- a/tests/dkan_dataset_class.test
+++ b/tests/dkan_dataset_class.test
@@ -118,6 +118,9 @@ class DkanDatasetClassWebTestCase extends DrupalWebTestCase {
     ctools_include('datasets', 'dkan_default_content');
     ctools_include('Dataset', 'dkan_dataset');
 
+    // Create taxonomies
+    dkan_default_content_taxonomy_create();
+
     // Create default content groups for datasets.
     $groups = dkan_default_content_available_groups();
     foreach ($groups as $key => $loadable) {


### PR DESCRIPTION
NuCivic/nucivic-internal#204
### Acceptance tests
- [x] git pull
- [x] drush en dkan_default_content
- [x] drush en dkan_dataset
- [x] drush test-run --xml 'DKAN Dataset' --uri=http://dkan/
- [x] Then it should pass all the tests 
