### PR TITLE
Modify logic to get format tags defaulting to "data"

### DIFF
--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -247,6 +247,26 @@ function dkan_dataset_get_resource_nodes($nid) {
 }
 
 /**
+ * Helper to get the format string for a resource node
+ *
+ * @param $node
+ *   A resource node
+ *
+ * @return
+ *   The format string (eg, "csv", "html", etc.). Defaults to "data".
+ */
+function dkan_dataset_get_resource_format($node) {
+  $node_wrapper = entity_metadata_wrapper('node', $node);
+  if ($node_wrapper->getBundle() != 'resource') {
+    return FALSE;
+  }
+  if (isset($node->field_format['und']) && $node_wrapper->field_format->value()->name) {
+    return $node_wrapper->field_format->value()->name; 
+  }
+  return 'data';
+}
+
+/**
  * Helper to get title from nid.
  */
 function dkan_dataset_get_title($nid) {

--- a/dkan_dataset.theme.inc
+++ b/dkan_dataset.theme.inc
@@ -141,7 +141,7 @@ function theme_dkan_dataset_resource_teaser_view($vars) {
     $links_data = array();
     foreach ($nodes as $node) {
       $node_wrapper = entity_metadata_wrapper('node', $node);
-      $name = isset($node->field_format['und']) ? $node_wrapper->field_format->value()->name : '';
+      $name = dkan_dataset_get_resource_format($node);
       $term = '';
       if (!isset($links_data[$name])) {
         $links_data[$name] = array(


### PR DESCRIPTION
Acceptance test:
- [x] Dataset that contains a resource with an empty "format" field shows as "data" on the dataset teaser
- [x] Dataset that contains a resource with a tag in the "format" with no text (this happens sometimes as a result of migration glitch) shos as "data" on the dataset teaser
