### PR TITLE
660 unpublished resources shown on dataset view

### DIFF
--- a/css/dkan_dataset.css
+++ b/css/dkan_dataset.css
@@ -307,6 +307,9 @@ li .heading:hover {
   margin: 1em 0;
   min-height: 60px;
 }
+.node-dataset .resource-list li.last i {
+  padding-left: 10px;
+}
 .node-resource .download .format-label {
   display: block;
   line-height: 50px;

--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -393,7 +393,13 @@ function dkan_dataset_download_access($node) {
   else {
     $node = entity_metadata_wrapper('node', $node);
     $resources = $node->field_resources->value();
-    if (count($resources)) {
+    $file_count = 0;
+    foreach ($resources as $resource) {
+      if (isset($resource->field_upload[LANGUAGE_NONE])) {
+        $file_count++;
+      }
+    }
+    if ($file_count) {
       return TRUE;
     }
   }

--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -399,7 +399,7 @@ function dkan_dataset_download_access($node) {
         $file_count++;
       }
     }
-    if ($file_count) {
+    if ($file_count > 1) {
       return TRUE;
     }
   }

--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -35,6 +35,15 @@ function dkan_dataset_menu() {
     'file' => 'dkan_dataset.pages.inc',
     'file path' => $path,
   );
+  $items['node/%node/dataset/download'] = array(
+    'title' => 'Download Dataset',
+    'page callback' => 'dkan_dataset_download',
+    'page arguments' => array(1),
+    'access callback' => 'dkan_dataset_download_access',
+    'access arguments' => array(1),
+    'file' => 'dkan_dataset.pages.inc',
+    'file path' => $path,
+  );
   $items['admin/dkan'] = array(
     'title' => 'DKAN',
     'description' => 'DKAN Settings and Administration.',
@@ -371,6 +380,22 @@ function dkan_dataset_back_access($node) {
   }
   else {
     return node_access('view', $node);
+  }
+}
+
+/**
+ * Access callback for 'Download Dataset' tab.
+ */
+function dkan_dataset_download_access($node) {
+  if ($node->type != 'dataset') {
+    return FALSE;
+  }
+  else {
+    $node = entity_metadata_wrapper('node', $node);
+    $resources = $node->field_resources->value();
+    if (count($resources)) {
+      return TRUE;
+    }
   }
 }
 

--- a/dkan_dataset.pages.inc
+++ b/dkan_dataset.pages.inc
@@ -27,3 +27,63 @@ function dkan_dataset_back($node) {
 function dkan_dataset_add_resource($node) {
   drupal_goto('node/add/resource', array('query' => array('dataset' => $node->nid)));
 }
+
+/**
+ * Callback for 'Download Dataset'.
+ */
+function dkan_dataset_download($node) {
+  $node = entity_metadata_wrapper('node', $node);
+  $resources = $node->field_resources->value();
+  if (isset($resources)) {
+    $files = array();
+    foreach ($resources as $resource) {
+      // Node could be empty if it has been deleted.
+      if (!$resource) {
+        continue;
+      }
+      $resource_wrapper = entity_metadata_wrapper('node', $resource);
+      if (isset($resource->field_upload[LANGUAGE_NONE])) {
+        $files[] = drupal_realpath($resource->field_upload[LANGUAGE_NONE][0]['uri']);
+      }
+    }
+    _dkan_dataset_zip($files, $node);
+  }
+}
+
+function _dkan_dataset_zip($files, $node) {
+  $zip = new ZipArchive;
+  $file_path = tempnam(file_directory_temp(), 'zip');
+  $zip_open = $zip->open($file_path, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE);
+  if ($zip_open === TRUE) {
+    foreach ($files as $file) {
+      if (file_exists($file)) {
+        if (!$zip->addFile(realpath($file), basename($file))) {
+          drupal_set_message(t('!file could not be added to Zip.', array('!file' => $file)), 'error');
+        }
+      }
+      else {
+        drupal_set_message('!file not found.', array('!file' => $file), 'error');
+      }
+    }
+    $zip->close();
+    $filename = _dkan_dataset_zip_filename($node->title->value());
+    $headers = array(
+      'Content-type' => 'application/zip',
+      'Content-Disposition' => 'attachment; filename="' . $filename . '"',
+      'Content-Length' => filesize($file_path)
+    );
+    file_transfer('temporary://' . basename($file_path), $headers);
+  }
+  else {
+    drupal_set_message(t('Unable to create file !filename.', array('!filename' => check_plain($filename))), 'error');
+    drupal_access_denied();
+    return FALSE;
+  }
+}
+
+function _dkan_dataset_zip_filename($title) {
+  $filename = strtr(drupal_strtolower($title), array(' ' => '-', '_' => '-', '[' => '-', ']' => ''));
+  $filename = preg_replace('/[^A-Za-z0-9\-_]/', '', $filename);
+  $filename = preg_replace('/\-+/', '-', $filename);
+  return $filename  . '-All-' . date('Y-m-d_Hi') . '.zip';
+}

--- a/dkan_dataset.pages.inc
+++ b/dkan_dataset.pages.inc
@@ -38,7 +38,7 @@ function dkan_dataset_download($node) {
     $files = array();
     foreach ($resources as $resource) {
       // Node could be empty if it has been deleted.
-      if (!$resource) {
+      if (!$resource || !$resource->status) {
         continue;
       }
       $resource_wrapper = entity_metadata_wrapper('node', $resource);

--- a/dkan_dataset.pages.inc
+++ b/dkan_dataset.pages.inc
@@ -38,7 +38,7 @@ function dkan_dataset_download($node) {
     $files = array();
     foreach ($resources as $resource) {
       // Node could be empty if it has been deleted.
-      if (!$resource || !$resource->status) {
+      if (!$resource || !node_access('view', $resource)) {
         continue;
       }
       $resource_wrapper = entity_metadata_wrapper('node', $resource);

--- a/dkan_dataset.theme.inc
+++ b/dkan_dataset.theme.inc
@@ -118,7 +118,7 @@ function theme_dkan_dataset_resource_view($vars) {
         ))
       ) . $desc . '<span class="links">' . $explore_link . $download_link . '</span></div>';
     }
-    if ($file_count) {
+    if ($file_count > 1) {
       $download_all = '<div property="dcat:Distribution"><span class="links">';
       $download_all .= l('Download All<i class="fa fa-download"><span> Download</span></i>', 'node/' . $vars['node']->nid . '/dataset/download', array(
         'html' => TRUE,

--- a/dkan_dataset.theme.inc
+++ b/dkan_dataset.theme.inc
@@ -116,7 +116,17 @@ function theme_dkan_dataset_resource_view($vars) {
         ))
       ) . $desc . '<span class="links">' . $explore_link . $download_link . '</span></div>';
     }
-
+    if (count($links)) {
+      $download_all = '<div property="dcat:Distribution"><span class="links">';
+      $download_all .= l('Download All<i class="fa fa-download"><span> Download</span></i>', 'node/' . $vars['node']->nid . '/dataset/download', array(
+        'html' => TRUE,
+        'attributes' => array(
+          'class' => array('btn', 'btn-primary')
+        )
+      ));
+      $download_all .= '</span></div>';
+      $links[] = $download_all;
+    }
     $output .= theme('item_list', array('items' => $links, 'attributes' => array('class' => array('resource-list'))));
     // Close first dcat declaration.
     $output .= '</div>';

--- a/dkan_dataset.theme.inc
+++ b/dkan_dataset.theme.inc
@@ -63,7 +63,7 @@ function theme_dkan_dataset_resource_view($vars) {
     $file_count = 0;
     foreach ($nodes as $node) {
       // Node could be empty if it has been deleted.
-      if (!$node) {
+      if (!$node || !node_access('view', $node)) {
         continue;
       }
       $node_wrapper = entity_metadata_wrapper('node', $node);

--- a/dkan_dataset.theme.inc
+++ b/dkan_dataset.theme.inc
@@ -60,6 +60,7 @@ function theme_dkan_dataset_resource_view($vars) {
   $output .= '<div property="dcat:distribution">';
 
   if (isset($nodes)) {
+    $file_count = 0;
     foreach ($nodes as $node) {
       // Node could be empty if it has been deleted.
       if (!$node) {
@@ -94,6 +95,7 @@ function theme_dkan_dataset_resource_view($vars) {
       );
       $download_link = '';
       if (isset($node->field_upload[LANGUAGE_NONE])) {
+        $file_count++;
         $url = file_create_url($node->field_upload[LANGUAGE_NONE][0]['uri']);
         $download_link = l(
           '<i class="fa fa-download"><span> Download</span></i>',
@@ -116,7 +118,7 @@ function theme_dkan_dataset_resource_view($vars) {
         ))
       ) . $desc . '<span class="links">' . $explore_link . $download_link . '</span></div>';
     }
-    if (count($links)) {
+    if ($file_count) {
       $download_all = '<div property="dcat:Distribution"><span class="links">';
       $download_all .= l('Download All<i class="fa fa-download"><span> Download</span></i>', 'node/' . $vars['node']->nid . '/dataset/download', array(
         'html' => TRUE,


### PR DESCRIPTION
This fixes the theme function that builds lists of resources for dataset node view.
It checks node access rights before listing the resources.
