### PR TITLE
Use most recent version of recline

### DIFF
--- a/dkan_dataset.make
+++ b/dkan_dataset.make
@@ -13,7 +13,6 @@ includes[leaflet_draw_widget_make] = https://raw.githubusercontent.com/NuCivic/l
 ; Recline specific
 projects[recline][download][type] = git
 projects[recline][download][url] = https://github.com/NuCivic/recline.git
-projects[recline][download][revision] = 66e3472fda78175f16b004dfd28ca9867061b9de
 projects[recline][download][branch] = 7.x-1.x
 projects[recline][subdir] = contrib
 

--- a/dkan_dataset.make
+++ b/dkan_dataset.make
@@ -13,7 +13,7 @@ includes[leaflet_draw_widget_make] = https://raw.githubusercontent.com/NuCivic/l
 ; Recline specific
 projects[recline][download][type] = git
 projects[recline][download][url] = https://github.com/NuCivic/recline.git
-projects[recline][download][revision] = a6af472a07d520a758f14cdf836a48c33e15bf07
+projects[recline][download][revision] = 66e3472fda78175f16b004dfd28ca9867061b9de
 projects[recline][download][branch] = 7.x-1.x
 projects[recline][subdir] = contrib
 


### PR DESCRIPTION
We need to use a more recent version of recline, so I changed the dkan_dataset.make in order to point to the version 7.x-1.x. This helps to fix the issue https://github.com/NuCivic/internal/issues/762
