### PR TITLE
NuCivic/internal#762: Patch into OG to fix errors with delete action integration with vbo.

### DIFF
--- a/dkan_dataset.make
+++ b/dkan_dataset.make
@@ -123,6 +123,7 @@ projects[multistep][type] = module
 
 projects[og][version] = 2.7
 projects[og][patch][1090438] = http://drupal.org/files/issues/og-add_users_and_entities_with_drush-1090438-12.patch
+projects[og][patch][2549071] = https://www.drupal.org/files/issues/og_actions-bug-vbo-delete.patch
 projects[og][subdir] = contrib
 
 projects[og_extras][download][type] = git


### PR DESCRIPTION
Change in the make file to add a patch to organic groups (https://www.drupal.org/files/issues/og_actions-bug-vbo-delete.patch), we should be able to delete group members without getting errors.
