### PR TITLE
NuCivic/ok_data#197 Add list of visualizations to the resouce page

### DIFF
--- a/css/dkan_dataset.css
+++ b/css/dkan_dataset.css
@@ -288,9 +288,61 @@ li .heading:hover {
   color: black;
   font-weight: bold ;
 }
+.item-list .list-group li {
+  margin:0;
+}
+.node-type-resource .item-list .list-group li {
+  margin: -1px;
+}
+.node-type-resource .list-group-item {
+  position: relative;
+  display: block;
+  padding: 10px 15px;
+  margin-bottom: -1px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 0px 0px 0px 0px;
+  -moz-border-radius: 0px 0px 0px 0px;
+  -webkit-border-radius: 0px 0px 0px 0px;
+}
+/* Move border-radius values from <li> to <a> */
+.node-type-resource .list-group-item:first-child,
+.node-type-resource .list-group-item:last-child {
+  border-radius: 0px 0px 0px 0px;
+  -moz-border-radius: 0px 0px 0px 0px;
+  -webkit-border-radius: 0px 0px 0px 0px;
+}
+.node-type-resource li.first a,
+.node-type-resource li.first .list-group-item:first-child,
+.node-type-resource li.first .list-group-item:last-child {
+  margin-bottom: 0;
+  border-radius: 4px 4px 0px 0px;
+  -moz-border-radius: 4px 4px 0px 0px;
+  -webkit-border-radius: 4px 4px 0px 0px;
+}
+.node-type-resource li.last a,
+.node-type-resource li.last .list-group-item:first-child,
+.node-type-resource li.last .list-group-item:last-child {
+  border-radius: 0px 0px 4px 4px;
+  -moz-border-radius: 0px 0px 4px 4px;
+  -webkit-border-radius: 0px 0px 4px 4px;
+}
+.node-type-resource li.first.last a,
+.node-type-resource li.first.last .list-group-item:first-child,
+.node-type-resource li.first.last .list-group-item:last-child {
+  border-radius: 4px;
+  -moz-border-radius: 4px;
+  -webkit-border-radius: 4px;
+}
+
+.item-list .list-group li,
+.item-list .list-group,
 .resource-list li,
 .resource-list {
   list-style-type: none;
+}
+.data-and-resources .resource-list li {
+  margin: 0;
 }
 .node-dataset .form-group .resource-list li {
   margin: 4px 10px 4px 0;

--- a/dkan_dataset.forms.inc
+++ b/dkan_dataset.forms.inc
@@ -623,6 +623,9 @@ function dkan_dataset_block_info() {
   $blocks['dkan_dataset_resource_nodes'] = array(
     'info' => t('Resources'),
   );
+  $blocks['dkan_dataset_visualizations_list'] = array(
+    'info' => t('Visualizations'),
+  );
   return $blocks;
 }
 
@@ -645,8 +648,13 @@ function dkan_dataset_block_view($delta = '') {
     case 'dkan_dataset_resource_nodes':
       $block['subject'] = t('Resources');
       $block['content'] = dkan_dataset_resource_nodes();
-
       break;
+
+    case 'dkan_dataset_visualizations_list':
+      $block['subject'] = t('Visualizations');
+      $block['content'] = dkan_dataset_visualizations_list();
+      break;
+
   }
 
   return $block;
@@ -691,12 +699,43 @@ function dkan_dataset_resource_nodes() {
   }
   if ($nodes) {
     foreach ($nodes as $node) {
-      $links[] = l('<span>' . $node->title . '</span>', 'node/' . $node->nid, array('html' => TRUE));
+      $attributes = array('attributes' => array('class' => array('list-group-item')),'html' => true);
+      $links[] = l('<span>' . $node->title . '</span>', 'node/' . $node->nid, $attributes);
     }
     if (!$current_node) {
       $links[] = '';
     }
-    $output = theme('item_list', array('items' => $links, 'attributes' => array('class' => array('nav-simple'))));
+    $output = theme('item_list', array('items' => $links, 'attributes' => array('class' => array('list-group'))));
+  }
+  return $output;
+}
+
+/**
+ * Returns list of visualizations based on a resource.
+ */
+function dkan_dataset_visualizations_list() {
+  $output = '';
+  $current_node = menu_get_object();
+  if (isset($current_node->type) && $current_node->type == 'resource') {
+    if($current_node->uuid) {
+      // Find all visualizations created from this resource.
+      $nodes = dkan_dataset_get_visualization_entities($current_node->uuid);
+    }
+    if ($nodes) {
+      foreach ($nodes as $node) {
+        $attributes = array('attributes' => array('class' => array('list-group-item')),'html' => true);
+        // Fetch title and type.
+        $result = db_query("SELECT type, title FROM {eck_visualization} WHERE id = :id", array(':id' => $node->nid));
+        foreach ($result as $row) {
+          // Add visualization to the list.
+          $links[] = l($row->title, 'visualization/' . $row->type . '/' . $node->nid, $attributes);
+        }
+      }
+      if (!$current_node) {
+        $links[] = '';
+      }
+      $output = theme('item_list', array('items' => $links, 'attributes' => array('class' => array('list-group'))));
+    }
   }
   return $output;
 }

--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -253,6 +253,30 @@ function dkan_dataset_get_resource_nodes($nid) {
 }
 
 /**
+ * Helper to get Visualization entities that are created from a Resource.
+ */
+function dkan_dataset_get_visualization_entities($uuid) {
+  $nodes = array();
+  $nids = array();
+  $query = new EntityFieldQuery();
+
+  $results = $query
+    ->entityCondition('entity_type', 'visualization')
+    ->fieldCondition('field_uuid_resource', 'target_uuid', $uuid, '=')
+    ->execute();
+
+  if ($results) {
+    foreach ($results as $node) {
+      foreach ($node as $uuid => $obj) {
+        $nids[] = $uuid;
+      }
+    }
+  }
+  $nodes = isset($nids) ? node_load_multiple($nids) : array();
+  return $nodes;
+}
+
+/**
  * Helper to get the format string for a resource node
  *
  * @param $node


### PR DESCRIPTION
• Editors need to know if a resource is being used for a visualization
• The published status of the resource will effect the visualization
• This commit includes the changes to the resource list block made in NuCivic/dkan#672
• Css updates for the resource list and visualization list blocks
