### PR TITLE
Fixed group issues in dkan_dataset_sync_groups.

### DIFF
--- a/dkan_dataset.forms.inc
+++ b/dkan_dataset.forms.inc
@@ -5,6 +5,8 @@
  * Form elements for DKAN.
  */
 
+include_once 'includes/getRemoteFileInfo.php';
+
 /**
  * Implements hook_field_group_build_pre_render_alter().
  */
@@ -301,6 +303,33 @@ function dkan_dataset_form_alter(&$form, &$form_state, $form_id) {
       $form['actions']['another']['#submit'] = array('node_form_submit', 'dkan_dataset_resource_form_submit');
     }
   }
+
+  if ($form_id == 'resource_node_form') {
+    $group_description = t("This resource is not assigned to any groups. Groups can only be assigned to Datasets. Resources are always a part of the parent Datasets's groups");
+    if (isset($form['og_group_ref'][$form['og_group_ref']['#language']][0]) && isset($form['og_group_ref'][$form['og_group_ref']['#language']][0]['#entity']->og_group_ref)) {
+      $titles = array();
+      foreach ($form['og_group_ref'][$form['og_group_ref']['#language']][0]['#entity']->og_group_ref['und'] as $group) {
+        $group = node_load($group['target_id']);
+        $titles[] = l($group->title, 'node/' . $group->nid);
+      }
+      $titles = theme('item_list', array('items' => $titles));
+      $group_description = t("This resource is in the following groups: !groups Groups can only be assigned to Datasets. Resources are always a part of the parent Datasets's groups.", array('!groups' => $titles));
+    }
+    else {
+      $group_description = t('No groups are attached to this resource. Groups can only be attached on datasets that resources are linked to.');
+    }
+
+    $form['og_group_ref']['#access'] = FALSE;
+    $form['groups'] = array(
+      '#type' => 'fieldset',
+      'und' => array(
+        '#type' => 'item',
+        '#markup' => $group_description,
+      ),
+      '#title' => t('Groups'),
+      '#group' => 'additional_settings',
+    );
+  }
 }
 
 /**
@@ -412,21 +441,9 @@ function dkan_dataset_resource_node_form_validate($form, &$form_state) {
         $type = isset($file->filemime) ? recline_get_data_type($file->filemime) : '';
       }
       elseif ($api) {
-        $request = drupal_http_request($api);
-        if (!isset($request->error)) {
-          // Remove char type or other info from content type.
-          $strpos = strpos($request->headers['content-type'], ';');
-          $mimetype = ($strpos !== FALSE) ? substr($request->headers['content-type'], 0, $strpos) : $request->headers['content-type'];
-          if (is_object(json_decode($request->data))) {
-            $type = 'json';
-          }
-          else {
-            $type = isset($file->filemime) ? recline_get_data_type($file->filemime) : '';
-          }
-        }
-      }
-      else {
-        $type = substr($link, strrpos($link, '.') + 1);
+        $file = new dkanDataset\getRemoteFileInfo($api, t('!site_name crawler', array('!site_name' => variable_get('site_name'))) , TRUE, file_directory_temp());
+        $filemime = $file->getType();
+        $type = recline_get_data_type($filemime);
       }
     }
   }
@@ -468,8 +485,8 @@ function dkan_dataset_resource_form_after_build($form, &$form_state) {
     $field_link_api_langcode = dkan_dataset_form_field_language($form, 'field_link_api');
 
     $form['field_link_file'][$field_link_file_langcode][0]['url']['#attributes']['placeholder'] = 'eg. http://example.com/gold-prices-jan-2011.csv';
-    $form['field_link_remote_file'][$field_link_file_langcode][0]['filefield_remotefile']['url']['#attributes']['placeholder'] = 'eg. http://example.com/gold-prices-jan-2011.csv';
-    $form['field_link_remote_file'][$field_link_file_langcode][0]['filefield_remotefile']['select']['#suffix'] = '';
+    $form['field_link_remote_file'][$field_link_file_langcode][0]['filefield_dkan_remotefile']['url']['#attributes']['placeholder'] = 'eg. http://example.com/gold-prices.csv';
+    $form['field_link_remote_file'][$field_link_file_langcode][0]['filefield_dkan_remotefile']['select']['#suffix'] = '';
     $form['field_link_api'][$field_link_api_langcode][0]['url']['#attributes']['placeholder'] = 'eg. http://example.com/gold-prices-jan-2011';
   }
   if (isset($form['field_format'])) {

--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -577,9 +577,11 @@ function dkan_dataset_sync_groups($node) {
             $resources_added[$nid] = $resource;
           }
         }
-        $additional_groups = dkan_dataset_resource_groups($resources_added, $node);
-        $groups_new = $groups_new + $additional_groups;
-        dkan_dataset_process_groups($resources_added, $groups_new);
+        if (!empty($resource->body)) {
+          $additional_groups = dkan_dataset_resource_groups($resources_added, $node);
+          $groups_new = $groups_new + $additional_groups;
+          dkan_dataset_process_groups($resources_added, $groups_new);
+        }
       }
       // Resources have been removed.
       if (array_diff_key($orig_resources, $new_resources)) {

--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -521,9 +521,9 @@ function dkan_dataset_sync_groups($node) {
   $groups_new = $node_new->__isset('og_group_ref') ? $node_new->og_group_ref->value() : '';
   if ($groups_new && $groups_orig) {
     // Resources.
-    $resources_new = $node_orig->__isset('field_resources') ? $node_orig->field_resources->value() : '';
-    $resources_orig = $node_new->__isset('field_resources') ? $node_new->field_resources->value() : '';
-    if ($resources_new && $resources_orig) {
+    $resources_orig = $node_orig->__isset('field_resources') ? $node_orig->field_resources->value() : '';
+    $resources_new = $node_new->__isset('field_resources') ? $node_new->field_resources->value() : '';
+    if ($resources_new) {
 
       $new_groups = array();
       $orig_groups = array();
@@ -546,9 +546,11 @@ function dkan_dataset_sync_groups($node) {
         foreach ($resources_new as $new_key => $new_resource) {
           $new_resources[$new_resource->nid] = $new_resource;
         }
-        foreach ($resources_orig as $orig_key => $orig_resource) {
-          if ($orig_resource) {
-            $orig_resources[$orig_resource->nid] = $orig_resource;
+        if ($resources_orig) {
+          foreach ($resources_orig as $orig_key => $orig_resource) {
+            if ($orig_resource) {
+              $orig_resources[$orig_resource->nid] = $orig_resource;
+            }
           }
         }
         // Groups have changed.
@@ -563,11 +565,16 @@ function dkan_dataset_sync_groups($node) {
       // Resources have been added.
       if (array_diff_key($new_resources, $orig_resources) && $groups_new) {
         foreach ($new_resources as $nid => $resource) {
-          foreach ($orig_resources as $orig_nid => $orig_resource) {
-            // Don't process unless the resource has a referenced dataset.
-            if (!isset($orig_resources[$nid]) && $resource->field_dataset_ref) {
-              $resources_added[$nid] = $resource;
+          if ($orig_resources) {
+            foreach ($orig_resources as $orig_nid => $orig_resource) {
+              // Don't process unless the resource has a referenced dataset.
+              if (!isset($orig_resources[$nid]) && $resource->field_dataset_ref) {
+                $resources_added[$nid] = $resource;
+              }
             }
+          }
+          else {
+            $resources_added[$nid] = $resource;
           }
         }
         $additional_groups = dkan_dataset_resource_groups($resources_added, $node);

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
@@ -21,6 +21,32 @@ function dkan_dataset_content_types_form_alter(&$form, &$form_state, $form_id) {
     $form['field_license'][LANGUAGE_NONE]['#options'] = $allowed_values;
 
   }
+  if ($form_id == 'resource_node_form') {
+    $group_description = t("This resource is not assigned to any groups. Groups can only be assigned to Datasets. Resources are always a part of the parent Datasets's groups");
+    if (isset($form['og_group_ref'][$form['og_group_ref']['#language']][0]['#entity']->og_group_ref)) {
+      $titles = array();
+      foreach ($form['og_group_ref'][$form['og_group_ref']['#language']][0]['#entity']->og_group_ref['und'] as $group) {
+        $group = node_load($group['target_id']);
+        $titles[] = l($group->title, 'node/' . $group->nid);
+      }
+      $titles = theme('item_list', array('items' => $titles));
+      $group_description = t("This resource is in the following groups: !groups Groups can only be assigned to Datasets. Resources are always a part of the parent Datasets's groups.", array('!groups' => $titles));
+    }
+    else {
+      $group_description = t('No groups are attached to this resource. Groups can only be attached on datasets that resources are linked to.');
+    }
+
+    $form['og_group_ref']['#access'] = FALSE;
+    $form['groups'] = array(
+      '#type' => 'fieldset',
+      'und' => array(
+        '#type' => 'item',
+        '#markup' => $group_description,
+      ),
+      '#title' => t('Groups'),
+      '#group' => 'additional_settings',
+    );
+  }
 }
 /**
  * Implements hook_field_formatter_info().

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
@@ -23,7 +23,7 @@ function dkan_dataset_content_types_form_alter(&$form, &$form_state, $form_id) {
   }
   if ($form_id == 'resource_node_form') {
     $group_description = t("This resource is not assigned to any groups. Groups can only be assigned to Datasets. Resources are always a part of the parent Datasets's groups");
-    if (isset($form['og_group_ref'][$form['og_group_ref']['#language']][0]['#entity']->og_group_ref)) {
+    if (isset($form['og_group_ref'][$form['og_group_ref']['#language']][0]) && isset($form['og_group_ref'][$form['og_group_ref']['#language']][0]['#entity']->og_group_ref)) {
       $titles = array();
       foreach ($form['og_group_ref'][$form['og_group_ref']['#language']][0]['#entity']->og_group_ref['und'] as $group) {
         $group = node_load($group['target_id']);

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
@@ -21,32 +21,6 @@ function dkan_dataset_content_types_form_alter(&$form, &$form_state, $form_id) {
     $form['field_license'][LANGUAGE_NONE]['#options'] = $allowed_values;
 
   }
-  if ($form_id == 'resource_node_form') {
-    $group_description = t("This resource is not assigned to any groups. Groups can only be assigned to Datasets. Resources are always a part of the parent Datasets's groups");
-    if (isset($form['og_group_ref'][$form['og_group_ref']['#language']][0]) && isset($form['og_group_ref'][$form['og_group_ref']['#language']][0]['#entity']->og_group_ref)) {
-      $titles = array();
-      foreach ($form['og_group_ref'][$form['og_group_ref']['#language']][0]['#entity']->og_group_ref['und'] as $group) {
-        $group = node_load($group['target_id']);
-        $titles[] = l($group->title, 'node/' . $group->nid);
-      }
-      $titles = theme('item_list', array('items' => $titles));
-      $group_description = t("This resource is in the following groups: !groups Groups can only be assigned to Datasets. Resources are always a part of the parent Datasets's groups.", array('!groups' => $titles));
-    }
-    else {
-      $group_description = t('No groups are attached to this resource. Groups can only be attached on datasets that resources are linked to.');
-    }
-
-    $form['og_group_ref']['#access'] = FALSE;
-    $form['groups'] = array(
-      '#type' => 'fieldset',
-      'und' => array(
-        '#type' => 'item',
-        '#markup' => $group_description,
-      ),
-      '#title' => t('Groups'),
-      '#group' => 'additional_settings',
-    );
-  }
 }
 /**
  * Implements hook_field_formatter_info().


### PR DESCRIPTION
There are some groups issues, to reproduce it follow the next steps:
1. Create a dataset, Dataset 1, link to "Group 1". Click "Add data".
2. Create a resource, Resource 1, click "add another".
3. Create a resource, Resource 2, click "save"

The problems are:
- [ ] Both Resource 1 and Resource 2 are not a member of Group 1
- [ ] A message pops up saying 
  ![9-17-2015 10-55-00 am](https://cloud.githubusercontent.com/assets/512243/10079536/407f3b9c-62b0-11e5-8b88-88cfdcc1e981.png)
# Acceptance test:

Then update the code to this branch and follow the steps described above, the results should be that both resources are part of Group 1 (you can check that in the resource edit page, you must see that they are linked to the respective group) and the message about removed items should not appear, instead we should have a message saying the number of resources that were added to the group or groups for that dataset.
