### PR TITLE
Fix group more links.

### DIFF
--- a/dkan_dataset.forms.inc
+++ b/dkan_dataset.forms.inc
@@ -199,6 +199,11 @@ function dkan_dataset_form_alter(&$form, &$form_state, $form_id) {
     // Get langcode for field_dataset_ref.
     $field_dataset_ref_langcode = dkan_dataset_form_field_language($form, 'field_dataset_ref');
     $form['field_dataset_ref'][$field_dataset_ref_langcode]['#description'] = t('Dataset that this resource is attached to.');
+    $dataset_options = $form['field_dataset_ref'][$field_dataset_ref_langcode]['#options'];
+    $fix_apostrophes = function($value) {
+      return html_entity_decode($value, ENT_QUOTES, "UTF-8");
+    };
+    $form['field_dataset_ref'][$field_dataset_ref_langcode]['#options'] = array_map($fix_apostrophes, $dataset_options);
 
     // Get langcode for field_upload.
     $field_upload_langcode = dkan_dataset_form_field_language($form, 'field_upload');

--- a/dkan_dataset.install
+++ b/dkan_dataset.install
@@ -19,6 +19,7 @@ function dkan_dataset_install() {
     ->execute();
 
   dkan_dataset_rdf_add_dcat();
+  _dkan_dataset_disable_og_extras_group_members_view();
 }
 
 /**
@@ -33,4 +34,27 @@ function dkan_dataset_rdf_add_dcat() {
 
   // Refresh the static variable that holds the array of namespaces.
   drupal_static_reset('rdfx_get_namespaces');
+}
+
+/**
+ * Disable the og_extras_members view.
+ *
+ * If we do not disable this view, there will be conflicts with the
+ * dkan_og_extras_members view.
+ */
+function _dkan_dataset_disable_og_extras_group_members_view() {
+  $views_status = variable_get('views_defaults', array());
+  $views_status['og_extras_members'] = TRUE;
+  variable_set('views_defaults', $views_status);
+
+  if (function_exists('views_invalidate_cache')) {
+    views_invalidate_cache();
+  }
+}
+
+/**
+ * Implements hook_update_N().
+ */
+function dkan_dataset_update_7001() {
+  _dkan_dataset_disable_og_extras_group_members_view();
 }

--- a/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
@@ -24,6 +24,7 @@ function dkan_dataset_groups_views_default_views() {
   $handler = $view->new_display('default', 'Defaults', 'default');
   $handler->display->display_options['use_more'] = TRUE;
   $handler->display->display_options['use_more_always'] = TRUE;
+  $handler->display->display_options['link_display'] = 'custom_url';
   $handler->display->display_options['access']['type'] = 'none';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
@@ -87,6 +88,7 @@ function dkan_dataset_groups_views_default_views() {
   /* Display: EVA Field */
   $handler = $view->new_display('entity_view', 'EVA Field', 'entity_view_1');
   $handler->display->display_options['defaults']['hide_admin_links'] = FALSE;
+  $handler->display->display_options['link_url'] = 'node/!1/members';
   $handler->display->display_options['entity_type'] = 'node';
   $handler->display->display_options['bundles'] = array(
     0 => 'group',
@@ -105,7 +107,7 @@ function dkan_dataset_groups_views_default_views() {
 
   /* Display: Defaults */
   $handler = $view->new_display('default', 'Defaults', 'default');
-  $handler->display->display_options['use_more_always'] = TRUE;
+  $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'none';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';


### PR DESCRIPTION
Ref: https://github.com/NuCivic/healthdata/issues/466
Ref: https://github.com/NuCivic/healthdata/issues/470
Ref: https://github.com/NuCivic/healthdata/issues/437

Acceptance:
- [ ] Group members page does not include "more" link back to itself.
- [ ] Group members block adds custom "more" link the works (i.e. doesn't go to page
  not found)
- [ ] When looking at the resource node form, any html entity in the datasets field (which is a list of dataset titles) is decoded.
- [ ] Disables og_extras_members view.
