### PR TITLE
Check the dataset update access for "Add Resource"

### DIFF
--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -429,7 +429,7 @@ function dkan_dataset_add_resource_access($node) {
   if ($node->type != 'dataset') {
     return FALSE;
   }
-  elseif (node_hook($node->type, 'form') && node_access('create', $node->type)) {
+  elseif (node_hook($node->type, 'form') && node_access('update', $node)) {
     return TRUE;
   }
   else {


### PR DESCRIPTION
Ref. NuCivic/usda-nal#714

Currently any user with the 'create dataset content' permission have access to the "Add Resource" tab even if he did not create the said dataset or his access level should not allow him to update it. This change will make the "Add Resource" visible to only users with the 'edit own dataset content' or the 'edit any dataset content' permissions.
#### Acceptance
- [x] Only users who can update an existing dataset have access to the "Add Resource" tab while viewing the said dataset.
