### PR TITLE
Fix "Members" button when Dataset group field is empty

### DIFF
--- a/modules/dkan_dataset_groups/dkan_dataset_groups.module
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.module
@@ -137,7 +137,7 @@ function dkan_dataset_groups_context_callback() {
     //Is a node group then use it.
     $group_node = $node;
   }
-  else {
+  elseif (!empty($node->og_group_ref)) {
     $group_node = node_load($node->og_group_ref[LANGUAGE_NONE][0]['target_id']);
   }
 


### PR DESCRIPTION
Ref. https://github.com/NuCivic/usda-nal/issues/595#issuecomment-162582849

> There is a new button when I access other users datasets however - it's called "members" and looks like this:
> ![members button](https://cloud.githubusercontent.com/assets/14111648/11632808/8a727056-9cd6-11e5-8869-5872dabddb8b.PNG)
> I get an error page when I click on it 
> ![members button error](https://cloud.githubusercontent.com/assets/14111648/11632825/9879d108-9cd6-11e5-98c5-7e824f402483.PNG).
### Acceptance
- [ ] Groupless Dataset "Members" button returns `Currently there are no members of this group.` instead of the error page.

Credits goes to @kerryhuller from USDA for bug report and QA.
