### PR TITLE
Fixed group breadcrumb caching issue (CIVIC-509)

### DIFF
--- a/modules/dkan_dataset_groups/dkan_dataset_groups.module
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.module
@@ -184,3 +184,8 @@ function dkan_dataset_groups_menu_breadcrumb_alter(&$active_trail, $item) {
     $active_trail = array_merge($part1, array( 1 => $groups_link), $part2);
   }
 }
+
+function dkan_dataset_groups_node_update($node) {
+  path_breadcrumbs_object_cache_clear("group");
+  cache_clear_all('*', PATH_BREADCRUMBS_CACHE_STORAGE, TRUE);
+}


### PR DESCRIPTION
ref https://jira.govdelivery.com/browse/CIVIC-509
### Acceptance
- Breadcrumb should change every time node title changes for 'group' content type.
