### PR TITLE
Fixed bug: wrong dataset count on groups page.

### DIFF
--- a/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
@@ -779,6 +779,7 @@ function dkan_dataset_groups_views_default_views() {
   $handler->display->display_options['arguments']['gid']['table'] = 'og_membership';
   $handler->display->display_options['arguments']['gid']['field'] = 'gid';
   $handler->display->display_options['arguments']['gid']['default_action'] = 'default';
+  $handler->display->display_options['arguments']['gid']['relationship'] = 'og_membership_rel';
   $handler->display->display_options['arguments']['gid']['default_argument_type'] = 'node';
   $handler->display->display_options['arguments']['gid']['summary']['number_of_records'] = '0';
   $handler->display->display_options['arguments']['gid']['summary']['format'] = 'default_summary';


### PR DESCRIPTION
ref https://jira.govdelivery.com/browse/CIVIC-514
### Acceptance
- Create a dataset and associate it with 2 groups. On the groups section the total dataset count should be fine.
