### PR TITLE
Remove og perms

### DIFF
--- a/dkan_dataset.make
+++ b/dkan_dataset.make
@@ -124,6 +124,7 @@ projects[multistep][type] = module
 projects[og][version] = 2.7
 projects[og][patch][1090438] = http://drupal.org/files/issues/og-add_users_and_entities_with_drush-1090438-12.patch
 projects[og][patch][2549071] = https://www.drupal.org/files/issues/og_actions-bug-vbo-delete.patch
+projects[og][patch][2301831] = https://www.drupal.org/files/issues/og-missing-permission-roles-2301831-1.patch
 projects[og][subdir] = contrib
 
 projects[og_extras][download][type] = git

--- a/modules/dkan_dataset_groups/modules/dkan_dataset_groups_perms/dkan_dataset_groups_perms.features.og_features_permission.inc
+++ b/modules/dkan_dataset_groups/modules/dkan_dataset_groups_perms/dkan_dataset_groups_perms.features.og_features_permission.inc
@@ -99,7 +99,6 @@ function dkan_dataset_groups_perms_og_features_default_permissions() {
   $permissions['node:group:delete any dataset content'] = array(
     'roles' => array(
       'administrator member' => 'administrator member',
-      'member' => 'member',
     ),
   );
 
@@ -107,7 +106,6 @@ function dkan_dataset_groups_perms_og_features_default_permissions() {
   $permissions['node:group:delete any resource content'] = array(
     'roles' => array(
       'administrator member' => 'administrator member',
-      'member' => 'member',
     ),
   );
 
@@ -172,7 +170,6 @@ function dkan_dataset_groups_perms_og_features_default_permissions() {
   $permissions['node:group:update any dataset content'] = array(
     'roles' => array(
       'administrator member' => 'administrator member',
-      'member' => 'member',
     ),
   );
 
@@ -180,7 +177,6 @@ function dkan_dataset_groups_perms_og_features_default_permissions() {
   $permissions['node:group:update any resource content'] = array(
     'roles' => array(
       'administrator member' => 'administrator member',
-      'member' => 'member',
     ),
   );
 


### PR DESCRIPTION
It removes og perms from members to prevent users attach contents to groups their are not within. It also  adds a patch to fix a problem when revert features during the installation process from drush.
