### PR TITLE
Allow for multiple geospatial features on map.

### DIFF
--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_base.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_base.inc
@@ -424,7 +424,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
   // Exported field_base: 'field_spatial'
   $field_bases['field_spatial'] = array(
     'active' => 1,
-    'cardinality' => 1,
+    'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_spatial',


### PR DESCRIPTION
Changes the cardinality of the geo spatial field to allow for multiple features
to be added to leaflet maps.

Ref nucivic/usda-nal#751
Ref nucivic/dkan#840
Ref nucivic/leaflet_draw_widget#10
### Acceptance:
- [ ] Once merged you should be able to add multiple geo spatial objects to this field.  See nucivic/dkan#840.
