### PR TITLE
Revert "Merge pull request #144 from NuCivic/travis-upgrade"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: false
 
 php:
   - 5.3
@@ -8,13 +7,7 @@ mysql:
   database: dkan_dataset_test
   username: root
   encoding: utf8
-  
-addons:
-  apt:
-    packages:
-    - php5-cgi
-    - php5-mysql
-    
+
 before_script:
   # navigate out of module directory to prevent blown stack by recursive module lookup
   - cd ../..
@@ -22,6 +15,10 @@ before_script:
   # Install drush from git clone
   - git clone --branch 6.x https://github.com/drush-ops/drush.git
   - export PATH="`pwd`/drush:$PATH"
+
+  # install php packages required for running a web server from drush on php 5.3
+  - sudo apt-get update > /dev/null
+  - sudo apt-get install -y --force-yes php5-cgi php5-mysql
 
   # disable sendmail
   - echo sendmail_path=`which true` >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
Forgot that upgrading travis would break it. We're not using travis anymore anyway soon, reverting for now.

This reverts commit b9fe816b0514c6cc4c32a369d6fd4ea1af2cb326, reversing
changes made to 49a33e87b97bb3d2fcd8e9c75a5f4edfd05987c1.
