### PR TITLE
Fix bug with localization in preview link

### DIFF
--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -881,7 +881,7 @@ function dkan_dataset_teaser_external_previews_for_resource($node) {
  */
 function dkan_dataset_preview_url_local($node) {
   if ($node->type == 'resource') {
-    return url('node/' . $node->nid);
+    return 'node/' . $node->nid;
   }
 }
 

--- a/dkan_dataset.theme.inc
+++ b/dkan_dataset.theme.inc
@@ -217,12 +217,9 @@ function theme_dkan_dataset_teaser_preview_link($vars) {
         <ul class="dropdown-menu">
       ';
       foreach ($previews as $provider => $preview) {
-        $preview_link .=
-          '<li class="' . $provider . ' ">
-            <a href="' . $preview['url'] . '" title="">
-              <span> ' . $preview['name'] . '</span>
-            </a>
-          </li>';
+        $preview_link .= '<li class="' . $provider . ' ">';
+        $preview_link .= l('<span> ' . $preview['name'] . '</span>', $preview['url'], array('html' => TRUE));
+        $preview_link .= '</li>';
       }
       $preview_link .= '</ul></div>';
     }


### PR DESCRIPTION
ref NuCivic/dkan#853 

Removes url() function from dkan_dataset_preview_url_local()
## Acceptance test
1. Enable "locale" and "content translation" modules.
2. Set language detection to "URL prefix"
3. Set language settings on Resource nodes to have multilingual enabled, with translation
4. Add another language besides English.
5. Assign the second language to a resource.
6. Go to resource's dataset. The link to preview should work.
