### PR TITLE
Remove caret margin when used in a button group

### DIFF
--- a/css/dkan_dataset.css
+++ b/css/dkan_dataset.css
@@ -620,6 +620,9 @@ body .node-dataset #data-and-resources ul.resource-list li .orig {
 #data-and-resources .btn .caret {
   margin: 0 0 0 5px;
 }
+#data-and-resources .btn-group .btn .caret {
+  margin: 0;
+}
 #data-and-resources .btn .fa-share {
   padding: 0 8px 0 0;
 }


### PR DESCRIPTION
## Acceptance Criteria
1. Go to this page and add options to the External Preview Settings
   http://dkan.local/admin/dkan/dataset_preview
2. Navigate to a dataset page and view the 'Open With' button, confirm the button half with the caret does not have a left margin on the icon.

![caret](https://cloud.githubusercontent.com/assets/314172/12360253/7cbc00e8-bb7c-11e5-9c28-de86a755c1d5.png)
