### PR TITLE
Fix list-group css so that it does not affect the navigation menu

### DIFF
--- a/css/dkan_dataset.css
+++ b/css/dkan_dataset.css
@@ -361,24 +361,24 @@ li .heading:hover {
   -moz-border-radius: 0px 0px 0px 0px;
   -webkit-border-radius: 0px 0px 0px 0px;
 }
-.node-type-resource li.first a,
-.node-type-resource li.first .list-group-item:first-child,
-.node-type-resource li.first .list-group-item:last-child {
+.node-type-resource .list-group li.first a,
+.node-type-resource .list-group li.first .list-group-item:first-child,
+.node-type-resource .list-group li.first .list-group-item:last-child {
   margin-bottom: 0;
   border-radius: 4px 4px 0px 0px;
   -moz-border-radius: 4px 4px 0px 0px;
   -webkit-border-radius: 4px 4px 0px 0px;
 }
-.node-type-resource li.last a,
-.node-type-resource li.last .list-group-item:first-child,
-.node-type-resource li.last .list-group-item:last-child {
+.node-type-resource .list-group li.last a,
+.node-type-resource .list-group li.last .list-group-item:first-child,
+.node-type-resource .list-group li.last .list-group-item:last-child {
   border-radius: 0px 0px 4px 4px;
   -moz-border-radius: 0px 0px 4px 4px;
   -webkit-border-radius: 0px 0px 4px 4px;
 }
-.node-type-resource li.first.last a,
-.node-type-resource li.first.last .list-group-item:first-child,
-.node-type-resource li.first.last .list-group-item:last-child {
+.node-type-resource .list-group li.first.last a,
+.node-type-resource .list-group li.first.last .list-group-item:first-child,
+.node-type-resource .list-group li.first.last .list-group-item:last-child {
   border-radius: 4px;
   -moz-border-radius: 4px;
   -webkit-border-radius: 4px;


### PR DESCRIPTION
## Issue

The css that styles the list group items, (resource list displayed on the bottom left of a resource page) was rounding the corners of the first and last items (on hover) of the navigation menu when on a resource page.

This PR updates the css to target the .list-group items, so the menu is not affected.

![screenshot_2_2_16__3_15_pm](https://cloud.githubusercontent.com/assets/314172/12764699/ead25710-c9c0-11e5-90e0-de137681a3fb.png)
