### PR TITLE
NuCivic#975 Update dkan_group_search view to include the correct results count

### DIFF
--- a/modules/dkan_dataset_groups/dkan_dataset_groups.features.field_instance.inc
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.features.field_instance.inc
@@ -26,6 +26,12 @@ function dkan_dataset_groups_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 5,
       ),
+      'search_result' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -150,6 +156,9 @@ function dkan_dataset_groups_field_default_field_instances() {
       'max_filesize' => '',
       'max_resolution' => '',
       'min_resolution' => '',
+      'resup' => 0,
+      'resup_autostart' => 0,
+      'resup_max_filesize' => '',
       'title_field' => 0,
       'user_register_form' => FALSE,
     ),

--- a/modules/dkan_dataset_groups/dkan_dataset_groups.features.inc
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.features.inc
@@ -165,18 +165,18 @@ function dkan_dataset_groups_default_search_api_index() {
       "index_directly" : 1,
       "cron_limit" : "50",
       "fields" : {
-        "type" : { "type" : "string" },
-        "title" : { "type" : "string" },
-        "status" : { "type" : "boolean" },
-        "changed" : { "type" : "date" },
         "author" : { "type" : "integer", "entity_type" : "user" },
+        "changed" : { "type" : "date" },
+        "field_resources:body:value" : { "type" : "list\\u003Ctext\\u003E" },
+        "field_resources:field_format" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "taxonomy_term" },
         "field_tags" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "taxonomy_term" },
         "og_group_ref" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "node" },
+        "search_api_access_node" : { "type" : "list\\u003Cstring\\u003E" },
         "search_api_language" : { "type" : "string" },
         "search_api_viewed" : { "type" : "text" },
-        "search_api_access_node" : { "type" : "list\\u003Cstring\\u003E" },
-        "field_resources:field_format" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "taxonomy_term" },
-        "field_resources:body:value" : { "type" : "list\\u003Ctext\\u003E" }
+        "status" : { "type" : "boolean" },
+        "title" : { "type" : "string" },
+        "type" : { "type" : "string" }
       },
       "data_alter_callbacks" : {
         "search_api_alter_bundle_filter" : {

--- a/modules/dkan_dataset_groups/dkan_dataset_groups.strongarm.inc
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.strongarm.inc
@@ -47,7 +47,7 @@ function dkan_dataset_groups_strongarm() {
           'weight' => '0',
         ),
       ),
-      'display' => array( ),
+      'display' => array(),
     ),
   );
   $export['field_bundle_settings_node__group'] = $strongarm;

--- a/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.views_default.inc
@@ -32,6 +32,11 @@ function dkan_dataset_groups_views_default_views() {
   $handler->display->display_options['style_plugin'] = 'default';
   $handler->display->display_options['row_plugin'] = 'entity';
   $handler->display->display_options['row_options']['view_mode'] = 'teaser';
+  /* Header: Global: Result summary */
+  $handler->display->display_options['header']['result']['id'] = 'result';
+  $handler->display->display_options['header']['result']['table'] = 'views';
+  $handler->display->display_options['header']['result']['field'] = 'result';
+  $handler->display->display_options['header']['result']['content'] = 'Displaying @start - @end of @total datasets';
   /* No results behavior: Global: Text area */
   $handler->display->display_options['empty']['area']['id'] = 'area';
   $handler->display->display_options['empty']['area']['table'] = 'views';
@@ -86,6 +91,13 @@ function dkan_dataset_groups_views_default_views() {
     3 => 0,
     6 => 0,
     4 => 0,
+  );
+  /* Filter criterion: Indexed Node: Status */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'search_api_index_groups_di';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = array(
+    1 => '1',
   );
 
   /* Display: Master */


### PR DESCRIPTION
## Issue

https://github.com/NuCivic/dkan/issues/975
## Tasks
- [x] Add results counter to the view header
- [x] Remove faulty counter from the view template (https://github.com/NuCivic/nuboot_radix/pull/68)
- [x] Filter by published
- [ ] Error: **An illegal choice has been detected. Please contact the site administrator.**
  When there are multiple pages of groups and you use the pager to go to the next page of groups you get this error on the exposed filter for 'filter by date changed' **<- This is Oklahoma specific**
## Dependent PRs

https://github.com/NuCivic/nuboot_radix/pull/68
