### PR TITLE
Save the exported code for the date_granularity on the date changed facet

### DIFF
--- a/modules/dkan_dataset_groups/dkan_dataset_groups.facetapi_defaults.inc
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.facetapi_defaults.inc
@@ -60,33 +60,21 @@ function dkan_dataset_groups_facetapi_default_facet_settings() {
       'active' => 'active',
       'count' => 'count',
       'display' => 'display',
-      'natural' => 0,
-      'indexed' => 0,
     ),
     'sort_weight' => array(
       'active' => '-50',
       'count' => '-49',
       'display' => '-48',
-      'natural' => '0',
-      'indexed' => '0',
     ),
     'sort_order' => array(
       'active' => '3',
       'count' => '3',
       'display' => '4',
-      'natural' => '4',
-      'indexed' => '4',
     ),
     'empty_behavior' => 'none',
     'soft_limit' => '20',
     'nofollow' => 1,
     'show_expanded' => 0,
-    'date_granularity' => 'DAY',
-    'empty_text' => array(
-      'value' => '',
-      'format' => 'html',
-    ),
-    'submit_realm' => 'Save and go back to realm settings',
   );
   $export['search_api@groups_di:block:changed'] = $facet;
   

--- a/modules/dkan_dataset_groups/dkan_dataset_groups.facetapi_defaults.inc
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.facetapi_defaults.inc
@@ -60,23 +60,65 @@ function dkan_dataset_groups_facetapi_default_facet_settings() {
       'active' => 'active',
       'count' => 'count',
       'display' => 'display',
+      'natural' => 0,
+      'indexed' => 0,
     ),
     'sort_weight' => array(
-      'active' => -50,
-      'count' => -49,
-      'display' => -48,
+      'active' => '-50',
+      'count' => '-49',
+      'display' => '-48',
+      'natural' => '0',
+      'indexed' => '0',
     ),
     'sort_order' => array(
-      'active' => 3,
-      'count' => 3,
-      'display' => 4,
+      'active' => '3',
+      'count' => '3',
+      'display' => '4',
+      'natural' => '4',
+      'indexed' => '4',
     ),
     'empty_behavior' => 'none',
-    'soft_limit' => 20,
+    'soft_limit' => '20',
     'nofollow' => 1,
     'show_expanded' => 0,
+    'date_granularity' => 'DAY',
+    'empty_text' => array(
+      'value' => '',
+      'format' => 'html',
+    ),
+    'submit_realm' => 'Save and go back to realm settings',
   );
   $export['search_api@groups_di:block:changed'] = $facet;
+  
+  $facet = new stdClass();
+  $facet->disabled = FALSE; /* Edit this to true to make a default facet disabled initially */
+  $facet->api_version = 1;
+  $facet->name = 'search_api@groups_di::changed';
+  $facet->searcher = 'search_api@groups_di';
+  $facet->realm = '';
+  $facet->facet = 'changed';
+  $facet->enabled = FALSE;
+  $facet->settings = array(
+    'operator' => 'and',
+    'hard_limit' => '50',
+    'dependencies' => array(
+      'facets' => array(),
+      'force_deactivation' => TRUE,
+      'regex' => FALSE,
+      'roles' => array(),
+      'bundle' => 'none',
+      'bundle_selected' => array(),
+    ),
+    'facet_mincount' => '1',
+    'facet_missing' => '0',
+    'flatten' => 0,
+    'query_type' => 'date',
+    'default_true' => TRUE,
+    'facet_search_ids' => array(),
+    'date_granularity' => 'DAY',
+    'pretty_paths_alias' => 'changed',
+  );
+  $export['search_api@groups_di::changed'] = $facet;
 
   $facet = new stdClass();
   $facet->disabled = FALSE; /* Edit this to true to make a default facet disabled initially */

--- a/modules/dkan_dataset_groups/dkan_dataset_groups.module
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.module
@@ -227,6 +227,5 @@ function dkan_dataset_groups_form_alter(&$form, $form_state, $form_id) {
         $form['sort_order']['#options']['DESC'] = t('Descending');
       }
       break;
-
   }
 }

--- a/modules/dkan_dataset_groups/dkan_dataset_groups.module
+++ b/modules/dkan_dataset_groups/dkan_dataset_groups.module
@@ -227,5 +227,6 @@ function dkan_dataset_groups_form_alter(&$form, $form_state, $form_id) {
         $form['sort_order']['#options']['DESC'] = t('Descending');
       }
       break;
+
   }
 }


### PR DESCRIPTION
## Issue

https://github.com/NuCivic/dkan/issues/976
## Details

Some facet configuration is not saved when you update a feature, the setting we need here is the date granularity on the date changed facet. To get this configuration into code, we did the following:
1. Navigate to the facet configuration screen for the groups index http://dkan.local/admin/config/search/search_api/index/groups_di/facets
2. Click 'Configure Display' on the date changed facet
3. Set the granulartity to 'Days' and save configuration
4. Go back to the facet configuration screen and this time click the arrow to reveal the other operation options.
5. Click on 'export configuration'
6. You will see two exports, one for **Display settings**, and one for  **Global settings**. The Global settings code must be manually added to the dkan_dataset_groups.facetapi_defaults.inc file.
7. To update an existing site the groups index will need to be re-indexed.

![screenshot_3_22_16__4_03_pm](https://cloud.githubusercontent.com/assets/314172/13968707/2f8f937a-f04c-11e5-8ee6-b35a8edc8fde.png)
## PR Dependencies

A PR was created on DKAN in order to add tests for this: https://github.com/NuCivic/dkan/pull/1023
