### PR TITLE
Change wording in resource form tabs

### DIFF
--- a/dkan_dataset.make
+++ b/dkan_dataset.make
@@ -13,10 +13,10 @@ includes[leaflet_draw_widget_make] = https://raw.githubusercontent.com/NuCivic/l
 ; Recline specific
 projects[recline][download][type] = git
 projects[recline][download][url] = https://github.com/NuCivic/recline.git
-projects[recline][download][branch] = 7.x-1.x
+projects[recline][download][branch] = dkan_data_proxy
 projects[recline][subdir] = contrib
 
-includes[recline_make] = https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make
+includes[recline_make] = https://raw.githubusercontent.com/NuCivic/recline/dkan_data_proxy/recline.make
 
 ; Contrib Modules
 projects[autocomplete_deluxe][subdir] = contrib

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.field_group.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.field_group.inc
@@ -132,14 +132,14 @@ function dkan_dataset_content_types_field_group_info() {
   $field_group->mode = 'form';
   $field_group->parent_name = 'group_data';
   $field_group->data = array(
-    'label' => 'URL',
+    'label' => 'API or Website URL',
     'weight' => '11',
     'children' => array(
       0 => 'field_link_api',
     ),
     'format_type' => 'htab',
     'format_settings' => array(
-      'label' => 'URL',
+      'label' => 'API or Website URL',
       'instance_settings' => array(
         'required_fields' => 1,
         'classes' => 'htab_link_api group-link-api field-group-htab',
@@ -220,14 +220,14 @@ function dkan_dataset_content_types_field_group_info() {
   $field_group->mode = 'form';
   $field_group->parent_name = 'group_data';
   $field_group->data = array(
-    'label' => 'Upload a file',
+    'label' => 'Upload',
     'weight' => '9',
     'children' => array(
       0 => 'field_upload',
     ),
     'format_type' => 'htab',
     'format_settings' => array(
-      'label' => 'Upload a file',
+      'label' => 'Upload',
       'instance_settings' => array(
         'required_fields' => 1,
         'classes' => 'htab_link_upload group-upload field-group-htab',
@@ -243,10 +243,10 @@ function dkan_dataset_content_types_field_group_info() {
   t('Dataset Info');
   t('Dataset Information');
   t('Remote file');
-  t('URL');
+  t('API or Website URL');
   t('Primary');
   t('Resource');
-  t('Upload a file');
+  t('Upload');
 
   return $field_groups;
 }

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.field_group.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.field_group.inc
@@ -132,14 +132,14 @@ function dkan_dataset_content_types_field_group_info() {
   $field_group->mode = 'form';
   $field_group->parent_name = 'group_data';
   $field_group->data = array(
-    'label' => 'Link to an API',
+    'label' => 'URL',
     'weight' => '11',
     'children' => array(
       0 => 'field_link_api',
     ),
     'format_type' => 'htab',
     'format_settings' => array(
-      'label' => 'Link to an API',
+      'label' => 'URL',
       'instance_settings' => array(
         'required_fields' => 1,
         'classes' => 'htab_link_api group-link-api field-group-htab',
@@ -160,14 +160,14 @@ function dkan_dataset_content_types_field_group_info() {
   $field_group->mode = 'form';
   $field_group->parent_name = 'group_data';
   $field_group->data = array(
-    'label' => 'Link to a file',
-    'weight' => '9',
+    'label' => 'Remote file',
+    'weight' => '12',
     'children' => array(
       0 => 'field_link_remote_file',
     ),
     'format_type' => 'htab',
     'format_settings' => array(
-      'label' => 'Link to a file',
+      'label' => 'Remote file',
       'instance_settings' => array(
         'required_fields' => 1,
         'classes' => 'htab_link_file group-link-file field-group-htab',
@@ -221,7 +221,7 @@ function dkan_dataset_content_types_field_group_info() {
   $field_group->parent_name = 'group_data';
   $field_group->data = array(
     'label' => 'Upload a file',
-    'weight' => '12',
+    'weight' => '9',
     'children' => array(
       0 => 'field_upload',
     ),
@@ -242,8 +242,8 @@ function dkan_dataset_content_types_field_group_info() {
   // Included for use with string extractors like potx.
   t('Dataset Info');
   t('Dataset Information');
-  t('Link to a file');
-  t('Link to an API');
+  t('Remote file');
+  t('URL');
   t('Primary');
   t('Resource');
   t('Upload a file');


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-3051
### Changes
- Change text in form resource tabs
- Remove restriction to upload only one file type during form validation
### Acceptance test
- [ ] Create a new resource
- [ ] Link to api now is called 'API or Website URL'. 
- [ ] Link to a file now it's called 'Remote file'. 
- [ ] Upload a file now it's called 'Upload'. 
- [ ] Click in save
- [ ] Both resources should be saved

This is the parent PR: https://github.com/NuCivic/dkan/pull/1236

**Remember to point recline branches to 7.x.1.x**
