### PR TITLE
Metadata urls as links

### DIFF
--- a/css/dkan_dataset.css
+++ b/css/dkan_dataset.css
@@ -678,3 +678,5 @@ body .node-dataset #data-and-resources ul.resource-list li .orig {
 #data-and-resources .btn .fa-share {
   padding: 0 8px 0 0;
 }
+.field-name-field-additional-info table p,
+.field-name-field-additional-info table p:last-child { margin: 0; }

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_base.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_base.inc
@@ -10,7 +10,7 @@
 function dkan_dataset_content_types_field_default_field_bases() {
   $field_bases = array();
 
-  // Exported field_base: 'body'
+  // Exported field_base: 'body'.
   $field_bases['body'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -31,7 +31,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'text_with_summary',
   );
 
-  // Exported field_base: 'field_additional_info'
+  // Exported field_base: 'field_additional_info'.
   $field_bases['field_additional_info'] = array(
     'active' => 1,
     'cardinality' => -1,
@@ -61,7 +61,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'double_field',
   );
 
-  // Exported field_base: 'field_author'
+  // Exported field_base: 'field_author'.
   $field_bases['field_author'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -82,7 +82,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_contact_email'
+  // Exported field_base: 'field_contact_email'.
   $field_bases['field_contact_email'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -103,7 +103,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_contact_name'
+  // Exported field_base: 'field_contact_name'.
   $field_bases['field_contact_name'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -124,7 +124,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_data_dictionary'
+  // Exported field_base: 'field_data_dictionary'.
   $field_bases['field_data_dictionary'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -143,7 +143,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'text_long',
   );
 
-  // Exported field_base: 'field_dataset_ref'
+  // Exported field_base: 'field_dataset_ref'.
   $field_bases['field_dataset_ref'] = array(
     'active' => 1,
     'cardinality' => -1,
@@ -181,7 +181,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'entityreference',
   );
 
-  // Exported field_base: 'field_format'
+  // Exported field_base: 'field_format'.
   $field_bases['field_format'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -207,7 +207,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'taxonomy_term_reference',
   );
 
-  // Exported field_base: 'field_frequency'
+  // Exported field_base: 'field_frequency'.
   $field_bases['field_frequency'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -236,7 +236,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'list_integer',
   );
 
-  // Exported field_base: 'field_granularity'
+  // Exported field_base: 'field_granularity'.
   $field_bases['field_granularity'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -257,7 +257,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_license'
+  // Exported field_base: 'field_license'.
   $field_bases['field_license'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -278,7 +278,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_link_api'
+  // Exported field_base: 'field_link_api'.
   $field_bases['field_link_api'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -307,7 +307,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'link_field',
   );
 
-  // Exported field_base: 'field_link_remote_file'
+  // Exported field_base: 'field_link_remote_file'.
   $field_bases['field_link_remote_file'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -330,7 +330,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'file',
   );
 
-  // Exported field_base: 'field_public_access_level'
+  // Exported field_base: 'field_public_access_level'.
   $field_bases['field_public_access_level'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -356,7 +356,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'list_text',
   );
 
-  // Exported field_base: 'field_related_content'
+  // Exported field_base: 'field_related_content'.
   $field_bases['field_related_content'] = array(
     'active' => 1,
     'cardinality' => -1,
@@ -385,7 +385,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'link_field',
   );
 
-  // Exported field_base: 'field_resources'
+  // Exported field_base: 'field_resources'.
   $field_bases['field_resources'] = array(
     'active' => 1,
     'cardinality' => -1,
@@ -421,7 +421,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'entityreference',
   );
 
-  // Exported field_base: 'field_spatial'
+  // Exported field_base: 'field_spatial'.
   $field_bases['field_spatial'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -436,7 +436,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'geofield',
   );
 
-  // Exported field_base: 'field_spatial_geographical_cover'
+  // Exported field_base: 'field_spatial_geographical_cover'.
   $field_bases['field_spatial_geographical_cover'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -457,7 +457,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_tags'
+  // Exported field_base: 'field_tags'.
   $field_bases['field_tags'] = array(
     'active' => 1,
     'cardinality' => -1,
@@ -483,7 +483,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'taxonomy_term_reference',
   );
 
-  // Exported field_base: 'field_temporal_coverage'
+  // Exported field_base: 'field_temporal_coverage'.
   $field_bases['field_temporal_coverage'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -512,7 +512,7 @@ function dkan_dataset_content_types_field_default_field_bases() {
     'type' => 'datetime',
   );
 
-  // Exported field_base: 'field_upload'
+  // Exported field_base: 'field_upload'.
   $field_bases['field_upload'] = array(
     'active' => 1,
     'cardinality' => 1,

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
@@ -10,7 +10,7 @@
 function dkan_dataset_content_types_field_default_field_instances() {
   $field_instances = array();
 
-  // Exported field_instance: 'node-dataset-body'
+  // Exported field_instance: 'node-dataset-body'.
   $field_instances['node-dataset-body'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -59,7 +59,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_additional_info'
+  // Exported field_instance: 'node-dataset-field_additional_info'.
   $field_instances['node-dataset-field_additional_info'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -71,13 +71,13 @@ function dkan_dataset_content_types_field_default_field_instances() {
         'module' => 'double_field',
         'settings' => array(
           'first' => array(
-            'format' => '_none',
+            'format' => 'plain_text',
             'hidden' => 0,
             'prefix' => '',
-            'suffix' => ':&nbsp;',
+            'suffix' => '',
           ),
           'second' => array(
-            'format' => '_none',
+            'format' => 'plain_text',
             'hidden' => 0,
             'prefix' => '',
             'suffix' => '',
@@ -173,7 +173,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_author'
+  // Exported field_instance: 'node-dataset-field_author'.
   $field_instances['node-dataset-field_author'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -220,7 +220,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_contact_email'
+  // Exported field_instance: 'node-dataset-field_contact_email'.
   $field_instances['node-dataset-field_contact_email'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -267,7 +267,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_contact_name'
+  // Exported field_instance: 'node-dataset-field_contact_name'.
   $field_instances['node-dataset-field_contact_name'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -314,7 +314,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_data_dictionary'
+  // Exported field_instance: 'node-dataset-field_data_dictionary'.
   $field_instances['node-dataset-field_data_dictionary'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -361,7 +361,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_frequency'
+  // Exported field_instance: 'node-dataset-field_frequency'.
   $field_instances['node-dataset-field_frequency'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -407,7 +407,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_granularity'
+  // Exported field_instance: 'node-dataset-field_granularity'.
   $field_instances['node-dataset-field_granularity'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -455,7 +455,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_license'
+  // Exported field_instance: 'node-dataset-field_license'.
   $field_instances['node-dataset-field_license'] = array(
     'bundle' => 'dataset',
     'default_value' => array(
@@ -528,7 +528,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_public_access_level'
+  // Exported field_instance: 'node-dataset-field_public_access_level'.
   $field_instances['node-dataset-field_public_access_level'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -574,7 +574,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_related_content'
+  // Exported field_instance: 'node-dataset-field_related_content'.
   $field_instances['node-dataset-field_related_content'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -636,7 +636,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_resources'
+  // Exported field_instance: 'node-dataset-field_resources'.
   $field_instances['node-dataset-field_resources'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -682,7 +682,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_spatial'
+  // Exported field_instance: 'node-dataset-field_spatial'.
   $field_instances['node-dataset-field_spatial'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -755,7 +755,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_spatial_geographical_cover'
+  // Exported field_instance: 'node-dataset-field_spatial_geographical_cover'.
   $field_instances['node-dataset-field_spatial_geographical_cover'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -802,7 +802,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_tags'
+  // Exported field_instance: 'node-dataset-field_tags'.
   $field_instances['node-dataset-field_tags'] = array(
     'bundle' => 'dataset',
     'default_value' => NULL,
@@ -851,7 +851,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-dataset-field_temporal_coverage'
+  // Exported field_instance: 'node-dataset-field_temporal_coverage'.
   $field_instances['node-dataset-field_temporal_coverage'] = array(
     'bundle' => 'dataset',
     'deleted' => 0,
@@ -917,7 +917,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-resource-body'
+  // Exported field_instance: 'node-resource-body'.
   $field_instances['node-resource-body'] = array(
     'bundle' => 'resource',
     'default_value' => NULL,
@@ -968,7 +968,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-resource-field_dataset_ref'
+  // Exported field_instance: 'node-resource-field_dataset_ref'.
   $field_instances['node-resource-field_dataset_ref'] = array(
     'bundle' => 'resource',
     'default_value' => NULL,
@@ -1012,7 +1012,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-resource-field_format'
+  // Exported field_instance: 'node-resource-field_format'.
   $field_instances['node-resource-field_format'] = array(
     'bundle' => 'resource',
     'default_value' => NULL,
@@ -1060,7 +1060,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-resource-field_link_api'
+  // Exported field_instance: 'node-resource-field_link_api'.
   $field_instances['node-resource-field_link_api'] = array(
     'bundle' => 'resource',
     'default_value' => NULL,
@@ -1126,7 +1126,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-resource-field_link_remote_file'
+  // Exported field_instance: 'node-resource-field_link_remote_file'.
   $field_instances['node-resource-field_link_remote_file'] = array(
     'bundle' => 'resource',
     'deleted' => 0,
@@ -1198,7 +1198,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-resource-field_upload'
+  // Exported field_instance: 'node-resource-field_upload'.
   $field_instances['node-resource-field_upload'] = array(
     'bundle' => 'resource',
     'deleted' => 0,
@@ -1251,7 +1251,7 @@ uk-ogl|UK Open Government Licence (OGL)',
     ),
   );
 
-  // Exported field_instance: 'node-resource-og_group_ref'
+  // Exported field_instance: 'node-resource-og_group_ref'.
   $field_instances['node-resource-og_group_ref'] = array(
     'bundle' => 'resource',
     'default_value' => NULL,

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
@@ -117,3 +117,18 @@ function dkan_dataset_content_types_alter_dataset_license(&$dataset, $key) {
     }
   }
 }
+
+/**
+ * Add links to metadata fields.
+ */
+function dkan_dataset_content_types_preprocess_field(&$vars) {
+  switch ($vars['element']['#field_name']) {
+    case 'field_contact_email':
+      $e = $vars['element']['#items'][0]['value'];
+      $vars['items']['0']['#markup'] = '<a href="mailto:' . $e . '">' . $e . '</a>';
+      break;
+
+  }
+  return;
+
+}


### PR DESCRIPTION
Issue: civic-2732
## Description

The metadata of DKAN datasets and resources often has fields for various hyperlinks such as “Agency Program URL,” “Technical Documentation,” etc. When hyperlinks occur in the metadata, they should display as clickable hyperlinks to the actual hyperlink destination.
## AC
- Add a contact email to a dataset, it should be a working link when viewing the dataset page.
- Add additional info with url values, these should also be links when viewed.
