### PR TITLE
Update dkan_dataset_content_types to fix rdf mapping overrides

### DIFF
--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.taxonomy.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.taxonomy.inc
@@ -16,6 +16,21 @@ function dkan_dataset_content_types_taxonomy_default_vocabularies() {
       'hierarchy' => 0,
       'module' => 'taxonomy',
       'weight' => 0,
+      'rdf_mapping' => array(
+        'rdftype' => array(
+          0 => 'skos:ConceptScheme',
+        ),
+        'name' => array(
+          'predicates' => array(
+            0 => 'dc:title',
+          ),
+        ),
+        'description' => array(
+          'predicates' => array(
+            0 => 'rdfs:comment',
+          ),
+        ),
+      ),
     ),
     'tags' => array(
       'name' => 'Tags',
@@ -24,6 +39,21 @@ function dkan_dataset_content_types_taxonomy_default_vocabularies() {
       'hierarchy' => 0,
       'module' => 'taxonomy',
       'weight' => 0,
+      'rdf_mapping' => array(
+        'rdftype' => array(
+          0 => 'skos:ConceptScheme',
+        ),
+        'name' => array(
+          'predicates' => array(
+            0 => 'dc:title',
+          ),
+        ),
+        'description' => array(
+          'predicates' => array(
+            0 => 'rdfs:comment',
+          ),
+        ),
+      ),
     ),
   );
 }

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.field_group.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.field_group.inc
@@ -241,11 +241,11 @@ function dkan_dataset_content_types_field_group_info() {
 
   // Translatables
   // Included for use with string extractors like potx.
+  t('API or Website URL');
   t('Dataset Info');
   t('Dataset Information');
-  t('Remote file');
-  t('API or Website URL');
   t('Primary');
+  t('Remote file');
   t('Resource');
   t('Upload');
 


### PR DESCRIPTION
## Issue

civic-3997
## Description

rdf mapping overrides on dkan_topics & dkan_dataset_content_types

![dkan_dataset_content_types___dkan](https://cloud.githubusercontent.com/assets/314172/18135872/01277628-6f69-11e6-801a-dc981dd9aad4.png)
## QA steps

confirm that dkan_dataset_content_types is not overridden on a fresh install
