### PR TITLE
Restore resource type count values on dataset teasers

### DIFF
--- a/css/dkan_dataset.css
+++ b/css/dkan_dataset.css
@@ -332,7 +332,7 @@ li .heading:hover {
 .item-list .list-group li {
   margin:0;
 }
-.node-type-resource .item-list .list-group li {
+.node-type-resource .pane-dkan-dataset-dkan-dataset-resource-nodes .item-list .list-group li {
   margin: -1px;
 }
 .node-type-resource .list-group-item {
@@ -436,6 +436,10 @@ li .heading:hover {
   top: auto;
   right: auto;
 }
+.resource-list .count-resource {
+  font-size: 12px;
+  vertical-align: baseline;
+}
 .resource-list .label {
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
@@ -443,10 +447,10 @@ li .heading:hover {
   background-color: olive;
   color: white;
   display: inline;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: bold;
-  line-height: 14px;
-  margin: 0 0 0 5px;
+  line-height: 16px;
+  margin: -3px 5px 0;
   padding: 1px 4px 2px;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   vertical-align: baseline;

--- a/dkan_dataset.theme.inc
+++ b/dkan_dataset.theme.inc
@@ -292,7 +292,12 @@ function theme_dkan_dataset_resource_teaser_view($vars) {
       }
     }
     foreach ($links_data as $term_name => $link) {
-      $links[] = l($term_name, $link['url'], $link['link']);
+      if($link['count'] > 1) {
+        $links[] = '<span class="count-resource">' . $link['count'] . 'x </span>' .  l($term_name, $link['url'], $link['link']);
+      }
+      else {
+        $links[] = l($term_name, $link['url'], $link['link']);
+      }
     }
     $output = theme('item_list', array('items' => $links, 'attributes' => array('class' => array('resource-list', 'clearfix'))));
   }


### PR DESCRIPTION
civic-3957
## Description

During the switch from the 'datasets' view to the 'search' view, the dataset teasers lost the count values on each resource type, this PR restores them.
## Acceptance Test
- [ ] Click 'Datasets' from the main menu, confirm that the list of datasets include count values on the resources they contain.

![dkan](https://cloud.githubusercontent.com/assets/314172/18292039/cdbc8200-7450-11e6-8b8c-fec5c3d47309.png)
