### PR TITLE
NuCivic/dkan#1187 Ability to turn off Viz Entity

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -47,6 +47,8 @@ dependencies:
     - wget http://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar
     - java -jar selenium-server-standalone-2.48.2.jar -quiet -p 4444 -log shut_up_selenium :
         background: true
+  pre:
+    - echo "memory_limit = 256M" > ~/.phpenv/versions/5.5.11/etc/conf.d/memory.ini
   post:
      - sudo apt-get install -y x11vnc
      - x11vnc -forever -nopw:

--- a/dkan_dataset.module
+++ b/dkan_dataset.module
@@ -260,6 +260,10 @@ function dkan_dataset_get_resource_nodes($nid) {
  * Helper to get Visualization entities that are created from a Resource.
  */
 function dkan_dataset_get_visualization_entities($uuid) {
+  // The EFQ will throw an error if the uuid_resource field doesn't exist.
+  if (!field_info_instance('visualization', 'field_uuid_resource','ve_chart')) {
+  return array();
+  }
   $nodes = array();
   $nids = array();
   $query = new EntityFieldQuery();


### PR DESCRIPTION
From: https://github.com/NuCivic/dkan/issues/1187

This checks for the existence of the `field_uuid_reference` before running the entity field query.

The real world scenario is that the Visualization Entity isn't turned on and the resource panel display contains a block the requests the Visualization Entities linked to that resource which runs that query.
## Acceptance Criteria
1. Link a Chart to a Resource and verify the Resource still displays linked visualization entity 
2. Manually delete Charts bundle at `/admin/structure/entity-type/visualization` which removes the `field_uuid_resource`
3. Verify resources don't white screen.
