### PR TITLE
Fixed error when clicking the 'View changes' button on a resource edi…

### DIFF
--- a/dkan_dataset.forms.inc
+++ b/dkan_dataset.forms.inc
@@ -361,6 +361,9 @@ function dkan_dataset_form_alter(&$form, &$form_state, $form_id) {
     }
     else {
       $form['#action'] = url('node/add/resource');
+      if (drupal_match_path(current_path(), 'node/*/edit')) {
+        $form['#action'] = url('node/' . $form['#node']->nid . '/edit');
+      }
     }
     if (variable_get('dkan_dataset_form_additional_info', 1 )) {
       if (isset($query['dataset']) || (isset($form_state['input']['field_dataset_ref']['und'][0]))) {


### PR DESCRIPTION
Ref https://github.com/NuCivic/wbddh/issues/377
## Steps to Reproduce
1. \- On any resource, click 'Edit'
2. \- Make a change to any field
3. \- Click 'View Changes'

A new resource is created with the changes. The original resource is unaltered, and there is no normal 'view changes' dialog.
