### PR TITLE
Update dictionary field to use plain text.

### DIFF
--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
@@ -410,7 +410,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     'label' => 'Data Dictionary',
     'required' => 0,
     'settings' => array(
-      'text_processing' => 1,
+      'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
     'widget' => array(


### PR DESCRIPTION
The dictionary field which maps to the open Data Schema "describedBy" field is
always a URL and if not added to a dataset as a plaintext URL the data.json
created with this field fails validation.

REF CIVIC-4269.

ORIG ISSUE: https://github.com/NuCivic/dkan/pull/1294
# QA Steps
- [ ] create data.json with open data schema map enabled.
- [ ] verify data.json is valid
