### PR TITLE
Remove jquery_update setting from dkan_dataset_content_types

### DIFF
--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
@@ -95,7 +95,6 @@ features[variable][] = chosen_minimum_multiple
 features[variable][] = chosen_minimum_single
 features[variable][] = field_bundle_settings_node__dataset
 features[variable][] = field_bundle_settings_node__resource
-features[variable][] = jquery_update_jquery_version
 features[variable][] = menu_options_dataset
 features[variable][] = menu_options_resource
 features[variable][] = menu_parent_dataset

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
@@ -197,13 +197,6 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
-  $strongarm->name = 'jquery_update_jquery_version';
-  $strongarm->value = '1.7';
-  $export['jquery_update_jquery_version'] = $strongarm;
-
-  $strongarm = new stdClass();
-  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
-  $strongarm->api_version = 1;
   $strongarm->name = 'menu_options_dataset';
   $strongarm->value = array();
   $export['menu_options_dataset'] = $strongarm;


### PR DESCRIPTION
We are setting the `jquery_update_jquery_version` variable value in dkan core
