### PR TITLE
Remove jquery_update setting from dkan_dataset_content_types

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,12 @@
 ## Customize the test machine
 machine:
 
-  timezone:
-    America/New_York # Set the timezone
+  #timezone:
+  #  America/New_York # Set the timezone
 
   # Version of ruby to use
   php:
-    version: '5.5.11'
+    version: '5.6.22'
 
   # Override /etc/hosts
   #hosts:
@@ -34,6 +34,14 @@ dependencies:
      #- "~/.drush"
      #- "~/backups"
      #- "test/sites/default"
+
+  pre:
+    - rm /opt/circleci/php/$(phpenv global)/etc/conf.d/xdebug.ini
+    - echo "memory_limit = 256M" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/memory.ini
+    - echo "always_populate_raw_post_data = -1" > $PHPENV_ROOT/versions/$(phpenv global)/etc/conf.d/deprecated.ini
+    - sudo apt-get update -y && sudo apt-get install -y x11vnc clamav clamav-freshclam
+    - yes | sudo perl -MCPAN -e "install Digest::HMAC_SHA1;"
+  
   override:
     - mkdir $CIRCLE_ARTIFACTS/junit
     - 'bash dkan-module-init.sh --deps --build=$DATABASE_URL'
@@ -44,8 +52,8 @@ dependencies:
     #- sh -e /etc/init.d/xvfb start
     #- sleep 3
 
-    - wget http://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar
-    - java -jar selenium-server-standalone-2.48.2.jar -quiet -p 4444 -log shut_up_selenium :
+    - wget http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar
+    - java -jar selenium-server-standalone-2.53.1.jar -p 4444 :
         background: true
   post:
      - sudo apt-get install -y x11vnc

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
@@ -95,7 +95,6 @@ features[variable][] = chosen_minimum_multiple
 features[variable][] = chosen_minimum_single
 features[variable][] = field_bundle_settings_node__dataset
 features[variable][] = field_bundle_settings_node__resource
-features[variable][] = jquery_update_jquery_version
 features[variable][] = menu_options_dataset
 features[variable][] = menu_options_resource
 features[variable][] = menu_parent_dataset

--- a/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
+++ b/modules/dkan_dataset_content_types/dkan_dataset_content_types.strongarm.inc
@@ -197,13 +197,6 @@ function dkan_dataset_content_types_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
-  $strongarm->name = 'jquery_update_jquery_version';
-  $strongarm->value = '1.7';
-  $export['jquery_update_jquery_version'] = $strongarm;
-
-  $strongarm = new stdClass();
-  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
-  $strongarm->api_version = 1;
   $strongarm->name = 'menu_options_dataset';
   $strongarm->value = array();
   $export['menu_options_dataset'] = $strongarm;


### PR DESCRIPTION
We are setting the `jquery_update_jquery_version` variable value in dkan core, the dkan_dataset_content_type feature displays as overridden

![dkan_dataset_content_types___dkan](https://cloud.githubusercontent.com/assets/314172/19369515/8ec9043c-916b-11e6-86a4-8863a90523dc.png)
