### PR TITLE
Fix resource file validation CIVIC-3687

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,8 @@ dependencies:
      #- "~/.drush"
      #- "~/backups"
      #- "test/sites/default"
+  pre:
+    - echo "memory_limit = 256M" > ~/.phpenv/versions/5.5.11/etc/conf.d/memory.ini
   override:
     - mkdir $CIRCLE_ARTIFACTS/junit
     - 'bash dkan-module-init.sh --deps --build=$DATABASE_URL'
@@ -47,6 +49,8 @@ dependencies:
     - wget http://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar
     - java -jar selenium-server-standalone-2.48.2.jar -quiet -p 4444 -log shut_up_selenium :
         background: true
+  pre:
+    - echo "memory_limit = 256M" > ~/.phpenv/versions/5.5.11/etc/conf.d/memory.ini
   post:
      - sudo apt-get install -y x11vnc
      - x11vnc -forever -nopw:

--- a/dkan_dataset.forms.inc
+++ b/dkan_dataset.forms.inc
@@ -388,7 +388,6 @@ function dkan_dataset_dataset_form_submit($form, &$form_state) {
  */
 function dkan_dataset_resource_node_form_validate($form, &$form_state) {
   // Get langcode for field_link_file.
-  $field_link_file_langcode = dkan_dataset_form_field_language($form, 'field_link_file');
   $field_link_remote_file_langcode = dkan_dataset_form_field_language($form, 'field_link_remote_file');
   // Get langcode for field_link_api.
   $field_link_api_langcode = dkan_dataset_form_field_language($form, 'field_link_api');
@@ -398,10 +397,10 @@ function dkan_dataset_resource_node_form_validate($form, &$form_state) {
   $field_format_langcode = dkan_dataset_form_field_language($form, 'field_format');
 
   // See if file link, api link, or file upload.
-  $link = isset($form_state['values']['field_link_file'][$field_link_file_langcode]) ? $form_state['values']['field_link_file'][$field_link_file_langcode][0]['url'] : NULL;
+  $link = isset($form_state['values']['field_link_remote_file'][$field_link_remote_file_langcode]) ? $form_state['values']['field_link_remote_file'][$field_link_remote_file_langcode][0]['filefield_remotefile']['url'] : NULL;
+  $link_fid = isset($form_state['values']['field_link_remote_file'][$field_link_remote_file_langcode]) ? $form_state['values']['field_link_remote_file'][$field_link_remote_file_langcode][0]['fid'] : NULL;
   $api = isset($form_state['values']['field_link_api']) ? $form_state['values']['field_link_api'][$field_link_api_langcode][0]['url'] : NULL;
-  $upload_fid = $form_state['values']['field_upload'][$field_upload_langcode][0]['fid'];
-  $link_fid = isset($form_state['values']['field_link_remote_file'][$field_upload_langcode]) ? $form_state['values']['field_link_remote_file'][$field_upload_langcode][0]['fid'] : NULL;
+  $upload_fid = isset($form_state['values']['field_upload'][$field_upload_langcode][0]['fid']) ? $form_state['values']['field_upload'][$field_upload_langcode][0]['fid'] : NULL;
 
   $format_name = isset($form_state['values']['field_format'][$field_upload_langcode][0]) ? $form_state['values']['field_format'][$field_upload_langcode][0]['name'] : NULL;
   $format_tid = isset($form_state['values']['field_format'][$field_upload_langcode][0]) ? $form_state['values']['field_format'][$field_upload_langcode][0]['tid'] : NULL;
@@ -432,8 +431,16 @@ function dkan_dataset_resource_node_form_validate($form, &$form_state) {
     }
   }
   // Ensure that only one type of resource is uploaded or linked to.
-  if ($link && ($api || $upload_fid || $link_fid) || $api && ($link || $upload_fid || $link_fid) || ($upload_fid && $api || $link) || ($link_fid && $api || $link)) {
-    form_set_error('field_link_file', 'Only one resource type can be added.');
+  if(count(array_filter(array($link_fid,$api,$upload_fid))) != 1) {
+    if ($link_fid) {
+      form_set_error('field_link_remote_file', 'Remote file option is populated - only one resource type can be used at a time.');
+    }
+    if ($api) {
+      form_set_error('field_link_api', 'API or Website URL is populated - only one resource type can be used at a time.');
+    }
+    if ($upload_fid) {
+      form_set_error('field_upload', 'File upload is populated - only one resource type can be used at a time.');
+    }
   }
   // Autodetect file type if a new one is not provided.
   if (!$type) {
@@ -495,16 +502,15 @@ function dkan_dataset_recline_format_alter(&$format, $entity) {
  * After build function for resource and dataset nodes.
  */
 function dkan_dataset_resource_form_after_build($form, &$form_state) {
-  if (isset($form['field_link_file'])) {
-    // Get langcode for field_link_file.
-    $field_link_file_langcode = dkan_dataset_form_field_language($form, 'field_link_file');
-    $field_link_remote_file_langcode = dkan_dataset_form_field_language($form, 'field_link_file');
+  if (isset($form['field_link_remote_file'])) {
+    // Get langcode for field_link_remote_file.
+    $field_link_remote_file_langcode = dkan_dataset_form_field_language($form, 'field_link_remote_file');
+    $form['field_link_remote_file'][$field_link_remote_file_langcode][0]['filefield_remotefile']['url']['#attributes']['placeholder'] = 'eg. http://example.com/gold-prices-jan-2011.csv';
+    $form['field_link_remote_file'][$field_link_remote_file_langcode][0]['filefield_remotefile']['select']['#suffix'] = '';
+  }
+  if (isset($form['field_link_api'])) {
     // Get langcode for field_link_api.
     $field_link_api_langcode = dkan_dataset_form_field_language($form, 'field_link_api');
-
-    $form['field_link_file'][$field_link_file_langcode][0]['url']['#attributes']['placeholder'] = 'eg. http://example.com/gold-prices-jan-2011.csv';
-    $form['field_link_remote_file'][$field_link_file_langcode][0]['filefield_remotefile']['url']['#attributes']['placeholder'] = 'eg. http://example.com/gold-prices-jan-2011.csv';
-    $form['field_link_remote_file'][$field_link_file_langcode][0]['filefield_remotefile']['select']['#suffix'] = '';
     $form['field_link_api'][$field_link_api_langcode][0]['url']['#attributes']['placeholder'] = 'eg. http://example.com/gold-prices-jan-2011';
   }
   if (isset($form['field_format'])) {

--- a/dkan_dataset.forms.inc
+++ b/dkan_dataset.forms.inc
@@ -430,13 +430,16 @@ function dkan_dataset_resource_node_form_validate($form, &$form_state) {
   // Ensure that only one type of resource is uploaded or linked to.
   if(count(array_filter(array($link_fid,$api,$upload_fid))) != 1) {
     if ($link_fid) {
-      form_set_error('field_link_remote_file', 'Remote file option is populated - only one resource type can be used at a time.');
+      $remote_error = t('<strong>Remote file</strong> is populated - only one resource type can be used at a time.');
+      form_set_error('field_link_remote_file', $remote_error);
     }
     if ($api) {
-      form_set_error('field_link_api', 'API or Website URL is populated - only one resource type can be used at a time.');
+      $api_error = t('<strong>API or Website URL</strong> is populated - only one resource type can be used at a time.');
+      form_set_error('field_link_api', $api_error);
     }
     if ($upload_fid) {
-      form_set_error('field_upload', 'File upload is populated - only one resource type can be used at a time.');
+      $upload_error = t('<strong>Upload</strong> is populated - only one resource type can be used at a time.');
+      form_set_error('field_upload', $upload_error);
     }
   }
   // Autodetect file type if a new one is not provided.

--- a/dkan_dataset.forms.inc
+++ b/dkan_dataset.forms.inc
@@ -218,11 +218,10 @@ function dkan_dataset_form_alter(&$form, &$form_state, $form_id) {
     $file_upload_validators = $form['field_upload'][$field_upload_langcode][0]['#file_resup_upload_validators'];
     $form['field_upload'][$field_upload_langcode][0]['#description'] = theme('file_upload_help', array('upload_validators' => $file_upload_validators));
 
-    // Get langcode for field_link_file.
-    $field_link_file_langcode = dkan_dataset_form_field_language($form, 'field_link_file');
+    // Get langcode for field_link_remote_file.
     $field_link_remote_file_langcode = dkan_dataset_form_field_language($form, 'field_link_remote_file');
-    $form['field_link_file'][$field_link_file_langcode][0]['#description'] = 'Link to a CSV file that will be imported into the DKAN datastore.';
-    $form['field_link_remote_file'][$field_link_file_langcode][0]['#description'] = 'Link to a csv, html, xls, json, xlsx, doc, docx, rdf, txt, jpg, png, gif, tiff, pdf, odf, ods, odt, tsv, geojson, or xml file. CSV files can be imported into the DKAN datastore.';
+    $form['field_link_remote_file'][$field_link_remote_file_langcode][0]['#description'] = 'Link to a CSV file that will be imported into the DKAN datastore.';
+    $form['field_link_remote_file'][$field_link_remote_file_langcode][0]['#description'] = 'Link to a csv, html, xls, json, xlsx, doc, docx, rdf, txt, jpg, png, gif, tiff, pdf, odf, ods, odt, tsv, geojson, or xml file. CSV files can be imported into the DKAN datastore.';
 
     // Get langcode for field_link_api.
     $field_link_api_langcode = dkan_dataset_form_field_language($form, 'field_link_api');
@@ -232,9 +231,7 @@ function dkan_dataset_form_alter(&$form, &$form_state, $form_id) {
     $form['title']['#required'] = TRUE;
 
     $form['field_link_api'][$field_link_api_langcode][0]['#title'] = '';
-
-    $form['field_link_file'][$field_link_file_langcode][0]['#title'] = '';
-    $form['field_link_remote_file'][$field_link_file_langcode][0]['#title'] = '';
+    $form['field_link_remote_file'][$field_link_remote_file_langcode][0]['#title'] = '';
 
     // Move groups to vertical tabs.
     if (isset($form['og_group_ref'])) {
@@ -387,7 +384,7 @@ function dkan_dataset_dataset_form_submit($form, &$form_state) {
  * Validation function for resource node form.
  */
 function dkan_dataset_resource_node_form_validate($form, &$form_state) {
-  // Get langcode for field_link_file.
+  // Get langcode for field_link_remote_file.
   $field_link_remote_file_langcode = dkan_dataset_form_field_language($form, 'field_link_remote_file');
   // Get langcode for field_link_api.
   $field_link_api_langcode = dkan_dataset_form_field_language($form, 'field_link_api');


### PR DESCRIPTION
issue: CIVIC-3687

## Description
When a user tries to fill in more than one of the file fields, they should get an error that instructs them to just use one.

## QA steps

1. Create a resource, add a remote file and upload a file, then save
2. Confirm you get an error

## PR dependencies
https://github.com/NuCivic/nuboot_radix/pull/102