### PR TITLE
Add patch for field_group for cross-site scripting Civic 4866

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 --------------------------
 - Upgrade Features to 7.x-2.9
 - Make date facet use "day" granularity.
+- Add patch to field_group to avoid DOM-based cross-site scripting vulnerabilities.
 
 7.x-1.11 2016-02-02
 --------------------------

--- a/dkan_dataset.make
+++ b/dkan_dataset.make
@@ -76,6 +76,7 @@ projects[features][subdir] = contrib
 
 projects[field_group][version] = 1.5
 projects[field_group][patch][2042681] = http://drupal.org/files/issues/field-group-show-ajax-2042681-8.patch
+projects[field_group][patch][2831815] = https://www.drupal.org/files/issues/hash-location-sanitization.diff
 projects[field_group][subdir] = contrib
 
 projects[field_group_table][download][type] = git


### PR DESCRIPTION
Issue: Civic 5345

## Description
DOM-based cross-site scripting arises when a script writes controllable data into the HTML document in an unsafe way. 

## QA Steps
1. Log in and open a dataset form
2. Confirm the field_group fields function properly (ie click on "Upload", "API")