### PR TITLE
Update autocomplete_deluxe to 2.2

### DIFF
--- a/dkan_dataset.make
+++ b/dkan_dataset.make
@@ -20,7 +20,7 @@ includes[recline_make] = https://raw.githubusercontent.com/NuCivic/recline/relea
 
 ; Contrib Modules
 projects[autocomplete_deluxe][subdir] = contrib
-projects[autocomplete_deluxe][version] = 2.1
+projects[autocomplete_deluxe][version] = 2.2
 
 projects[beautytips][download][type] = git
 projects[beautytips][download][branch] = 7.x-2.x


### PR DESCRIPTION
This addresses DKAN security alert [DRUPAL-SA-CONTRIB-2017-003 ](https://www.drupal.org/node/2842730) on the 1.12 release branch

## QA Tests

* Autocomplete deluxe field (the keywords in dataset) behaves as normal
* WAVE 508 tests still pass on dataset form

QA on NuCivic/dkan#1686